### PR TITLE
Fix JSONL parsing crash on malformed Unicode and UI polish

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -692,6 +692,7 @@ PluginComponent {
                     width: parent.width
                     height: allTimeRow.implicitHeight + Theme.spacingM * 2
                     color: Theme.surfaceContainerHigh
+                    visible: root.alltimeSessions > 0 || root.alltimeMessages > 0
 
                     Row {
                         id: allTimeRow
@@ -722,6 +723,9 @@ PluginComponent {
                         }
                     }
                 }
+
+                // Bottom padding to match sides (compensates Column spacing)
+                Item { width: 1; height: 1 }
             }
         }
     }

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -71,8 +71,8 @@ if [ -d "$PROJECTS_DIR" ]; then
             DAILY) DAILY="$value" ;;
             WEEK_MODELS) WEEK_MODELS="$value" ;;
         esac
-    done < <(find "$PROJECTS_DIR" -name "*.jsonl" -mtime -31 -exec \
-        jq -r 'select(.type == "assistant") | "\(.timestamp[:10]) \(.message.model // "unknown") \(.message.usage.input_tokens + .message.usage.output_tokens + .message.usage.cache_read_input_tokens + .message.usage.cache_creation_input_tokens) \(.sessionId // "unknown")"' {} + 2>/dev/null \
+    done < <(find "$PROJECTS_DIR" -name "*.jsonl" -mtime -31 -exec cat {} + 2>/dev/null \
+        | jq -r -R 'fromjson? | select(.type == "assistant") | "\(.timestamp[:10]) \(.message.model // "unknown") \((.message.usage.input_tokens // 0) + (.message.usage.output_tokens // 0) + (.message.usage.cache_read_input_tokens // 0) + (.message.usage.cache_creation_input_tokens // 0)) \(.sessionId // "unknown")"' \
         | awk -v week_start="$SEVEN_DAYS_AGO" -v month_start="$MONTH_START" -v day_dates="$DAY_DATES" '
         BEGIN { split(day_dates, dates, ",") }
         {


### PR DESCRIPTION
## Summary
- **Fix critical bug**: `jq` crashed silently on malformed Unicode surrogate pairs in JSONL session files, causing all subsequent daily consumption data to be lost. Now uses `fromjson?` with raw input to gracefully skip bad lines.
- **Hide empty all-time stats card** when `stats-cache.json` is missing (e.g. after a `.claude` directory reset)
- **Add bottom padding** to popout for consistent spacing

## Test plan
- [x] Verify daily activity chart shows data for all recent days (including today)
- [x] Verify all-time footer card is hidden when stats-cache.json is absent
- [x] Verify bottom padding of the popout matches top/sides spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)