### PR TITLE
Make model family detection fully dynamic

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -121,10 +121,8 @@ PluginComponent {
     }
 
     function shortModelName(name) {
-        if (name.indexOf("opus") >= 0) return "Opus"
-        if (name.indexOf("sonnet") >= 0) return "Sonnet"
-        if (name.indexOf("haiku") >= 0) return "Haiku"
-        return name
+        if (!name || name.length === 0) return name
+        return name.charAt(0).toUpperCase() + name.slice(1)
     }
 
     function progressColor(pct) {

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -42,30 +42,29 @@ PRICING_JSON=""
 refresh_pricing() {
     local raw
     raw=$(curl -s --max-time 10 "$LITELLM_URL" 2>/dev/null) || return 1
-    # Extract canonical Anthropic direct API prices for each family
+    # Dynamically extract pricing for all Claude model families
+    # Pattern: "claude-{family}-{major}-{minor}" (no date suffix, no provider prefix)
+    # Groups by family name, takes the latest version per family
     local result
     result=$(echo "$raw" | jq -c '{
         updated: "'"$TODAY"'",
-        models: {
-            opus: (to_entries | map(select(.key == "claude-opus-4-6")) | first // null | .value | {
-                input: .input_cost_per_token,
-                output: .output_cost_per_token,
-                cache_read: .cache_read_input_token_cost,
-                cache_write: .cache_creation_input_token_cost
-            }),
-            sonnet: (to_entries | map(select(.key == "claude-sonnet-4-6")) | first // null | .value | {
-                input: .input_cost_per_token,
-                output: .output_cost_per_token,
-                cache_read: .cache_read_input_token_cost,
-                cache_write: .cache_creation_input_token_cost
-            }),
-            haiku: (to_entries | map(select(.key == "claude-haiku-4-5")) | first // null | .value | {
-                input: .input_cost_per_token,
-                output: .output_cost_per_token,
-                cache_read: .cache_read_input_token_cost,
-                cache_write: .cache_creation_input_token_cost
-            })
-        }
+        models: ([to_entries[]
+            | select(.key | test("^claude-[a-z]+-[0-9]+-[0-9]+$"))
+            | select(.value.input_cost_per_token > 0)
+            | {
+                family: (.key | split("-") | .[1]),
+                key: .key,
+                value: .value
+              }
+        ] | group_by(.family)
+          | map(sort_by(.key) | last
+              | {key: .family, value: {
+                    input: .value.input_cost_per_token,
+                    output: .value.output_cost_per_token,
+                    cache_read: .value.cache_read_input_token_cost,
+                    cache_write: .value.cache_creation_input_token_cost
+                }})
+          | from_entries)
     }' 2>/dev/null) || return 1
     # Fetch USD→EUR exchange rate from ECB via Frankfurter
     local eur_rate
@@ -173,11 +172,9 @@ if [ -d "$PROJECTS_DIR" ]; then
             sess = $7
             total = inp + out + cr + cw
 
-            # Determine model family
-            family = model
-            if (index(family, "opus") > 0) family = "opus"
-            else if (index(family, "sonnet") > 0) family = "sonnet"
-            else if (index(family, "haiku") > 0) family = "haiku"
+            # Extract family from model name (claude-{family}-{version...})
+            n_parts = split(model, mparts, "-")
+            family = (n_parts >= 3 && mparts[1] == "claude") ? mparts[2] : model
 
             # Token aggregation (same as before)
             day[date] += total


### PR DESCRIPTION
## Summary
- **Pricing**: replace 3 hardcoded model lookups with dynamic discovery from LiteLLM — pattern `^claude-{family}-{major}-{minor}$`, grouped by family, latest version picked automatically
- **Awk**: extract family by `split(model, "-")[2]` instead of `index(family, "opus")` checks
- **QML**: `shortModelName()` now capitalizes any family name instead of hardcoded mapping

Any new Anthropic model family (e.g. `claude-newmodel-5-0`) will be automatically detected, priced, and displayed without code changes.

## Test plan
- [x] Verify pricing cache still contains opus/sonnet/haiku with correct prices
- [x] Verify model breakdown card displays correct family names (Opus, Sonnet, Haiku)
- [x] Verify cost calculation results are identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)