### PR TITLE
Add hover tooltip on daily activity chart

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -658,11 +658,16 @@ PluginComponent {
                                                     ? Theme.primary
                                                     : index === root.todayIndex ? Theme.primary : Theme.surfaceVariant
                                                 opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
+
+                                                Behavior on opacity {
+                                                    NumberAnimation { duration: 120 }
+                                                }
                                             }
 
                                             MouseArea {
                                                 anchors.fill: parent
                                                 hoverEnabled: true
+                                                enabled: root.dailyTokens[index] > 0
                                                 onEntered: root.hoveredDay = index
                                                 onExited: root.hoveredDay = -1
                                             }
@@ -680,46 +685,51 @@ PluginComponent {
                                     }
                                 }
                             }
+                        }
+                    }
 
-                            // Tooltip on hover
-                            Rectangle {
-                                id: chartTooltip
-                                visible: root.hoveredDay >= 0 && root.dailyTokens[root.hoveredDay] > 0
-                                z: 10
+                    // Tooltip on hover — child of StyledRect to avoid clip issues
+                    Rectangle {
+                        id: chartTooltip
+                        visible: root.hoveredDay >= 0 && root.dailyTokens[root.hoveredDay] > 0
+                        z: 10
 
-                                x: {
-                                    var colW = (chartRow.width - 6 * 4) / 7
-                                    var cx = root.hoveredDay * (colW + 4) + colW / 2 - width / 2
-                                    return Math.max(0, Math.min(cx, parent.width - width))
-                                }
-                                y: -height - 2
+                        x: {
+                            var colW = (chartRow.width - 6 * 4) / 7
+                            var cx = root.hoveredDay * (colW + 4) + colW / 2 - width / 2
+                            var chartX = chartRow.mapToItem(chartTooltip.parent, 0, 0).x
+                            var raw = chartX + cx
+                            return Math.max(Theme.spacingM, Math.min(raw, parent.width - width - Theme.spacingM))
+                        }
+                        y: {
+                            var chartY = chartRow.mapToItem(chartTooltip.parent, 0, 0).y
+                            return chartY - height - 2
+                        }
 
-                                width: tooltipCol.width + Theme.spacingS * 2
-                                height: tooltipCol.height + Theme.spacingXS * 2
-                                radius: 4
-                                color: Theme.surfaceContainer
+                        width: tooltipCol.width + Theme.spacingS * 2
+                        height: tooltipCol.height + Theme.spacingXS * 2
+                        radius: 4
+                        color: Theme.surfaceContainer
 
-                                Column {
-                                    id: tooltipCol
-                                    anchors.centerIn: parent
-                                    spacing: 1
+                        Column {
+                            id: tooltipCol
+                            anchors.centerIn: parent
+                            spacing: 1
 
-                                    StyledText {
-                                        text: root.hoveredDay >= 0 ? root.formatTokens(root.dailyTokens[root.hoveredDay]) : ""
-                                        font.pixelSize: 11
-                                        font.weight: Font.DemiBold
-                                        color: Theme.surfaceText
-                                        anchors.horizontalCenter: parent.horizontalCenter
-                                    }
+                            StyledText {
+                                text: root.hoveredDay >= 0 ? root.formatTokens(root.dailyTokens[root.hoveredDay]) : ""
+                                font.pixelSize: 11
+                                font.weight: Font.DemiBold
+                                color: Theme.surfaceText
+                                anchors.horizontalCenter: parent.horizontalCenter
+                            }
 
-                                    StyledText {
-                                        visible: root.hoveredDay >= 0 && root.dailyCosts[root.hoveredDay] > 0
-                                        text: root.hoveredDay >= 0 ? root.formatCost(root.dailyCosts[root.hoveredDay]) : ""
-                                        font.pixelSize: 11
-                                        color: Theme.surfaceVariantText
-                                        anchors.horizontalCenter: parent.horizontalCenter
-                                    }
-                                }
+                            StyledText {
+                                visible: root.hoveredDay >= 0 && root.dailyCosts[root.hoveredDay] > 0
+                                text: root.hoveredDay >= 0 ? root.formatCost(root.dailyCosts[root.hoveredDay]) : ""
+                                font.pixelSize: 11
+                                color: Theme.surfaceVariantText
+                                anchors.horizontalCenter: parent.horizontalCenter
                             }
                         }
                     }

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -60,7 +60,11 @@ PluginComponent {
     property real todayCost: 0
     property real weekCost: 0
     property real monthCost: 0
+    property var dailyCosts: [0, 0, 0, 0, 0, 0, 0]
     property real usdEurRate: 0
+
+    // Chart hover state
+    property int hoveredDay: -1
 
     // Model list
     ListModel { id: modelListData }
@@ -195,6 +199,13 @@ PluginComponent {
         case "WEEK_COST": weekCost = parseFloat(val) || 0; break
         case "MONTH_COST": monthCost = parseFloat(val) || 0; break
         case "USD_EUR_RATE": usdEurRate = parseFloat(val) || 0; break
+        case "DAILY_COSTS":
+            var cparts = val.split(",")
+            var carr = []
+            for (var k = 0; k < 7; k++)
+                carr.push(k < cparts.length ? (parseFloat(cparts[k]) || 0) : 0)
+            dailyCosts = carr
+            break
         }
     }
 
@@ -643,7 +654,17 @@ PluginComponent {
                                                     ? Math.max(root.dailyTokens[index] / root.maxDaily * parent.height, root.dailyTokens[index] > 0 ? 3 : 0)
                                                     : 0
                                                 radius: 2
-                                                color: index === root.todayIndex ? Theme.primary : Theme.surfaceVariant
+                                                color: index === root.hoveredDay
+                                                    ? Theme.primary
+                                                    : index === root.todayIndex ? Theme.primary : Theme.surfaceVariant
+                                                opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
+                                            }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                hoverEnabled: true
+                                                onEntered: root.hoveredDay = index
+                                                onExited: root.hoveredDay = -1
                                             }
                                         }
 
@@ -651,9 +672,52 @@ PluginComponent {
                                             id: dayLabel
                                             text: root.dayLabels[index]
                                             font.pixelSize: 11
-                                            color: index === root.todayIndex ? Theme.primary : Theme.surfaceVariantText
+                                            color: index === root.hoveredDay
+                                                ? Theme.primary
+                                                : index === root.todayIndex ? Theme.primary : Theme.surfaceVariantText
                                             anchors.horizontalCenter: parent.horizontalCenter
                                         }
+                                    }
+                                }
+                            }
+
+                            // Tooltip on hover
+                            Rectangle {
+                                id: chartTooltip
+                                visible: root.hoveredDay >= 0 && root.dailyTokens[root.hoveredDay] > 0
+                                z: 10
+
+                                x: {
+                                    var colW = (chartRow.width - 6 * 4) / 7
+                                    var cx = root.hoveredDay * (colW + 4) + colW / 2 - width / 2
+                                    return Math.max(0, Math.min(cx, parent.width - width))
+                                }
+                                y: -height - 2
+
+                                width: tooltipCol.width + Theme.spacingS * 2
+                                height: tooltipCol.height + Theme.spacingXS * 2
+                                radius: 4
+                                color: Theme.surfaceContainer
+
+                                Column {
+                                    id: tooltipCol
+                                    anchors.centerIn: parent
+                                    spacing: 1
+
+                                    StyledText {
+                                        text: root.hoveredDay >= 0 ? root.formatTokens(root.dailyTokens[root.hoveredDay]) : ""
+                                        font.pixelSize: 11
+                                        font.weight: Font.DemiBold
+                                        color: Theme.surfaceText
+                                        anchors.horizontalCenter: parent.horizontalCenter
+                                    }
+
+                                    StyledText {
+                                        visible: root.hoveredDay >= 0 && root.dailyCosts[root.hoveredDay] > 0
+                                        text: root.hoveredDay >= 0 ? root.formatCost(root.dailyCosts[root.hoveredDay]) : ""
+                                        font.pixelSize: 11
+                                        color: Theme.surfaceVariantText
+                                        anchors.horizontalCenter: parent.horizontalCenter
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- Adds interactive hover tooltip on daily activity chart bars showing token count and estimated cost
- Non-hovered bars dim to 40% opacity for visual focus
- Day labels highlight on hover
- Tooltip auto-positions to stay within chart bounds

## Changes
- `ClaudeCodeUsageWidget.qml`: Added `dailyCosts` property + parsing, `hoveredDay` state, MouseArea on bars, floating tooltip Rectangle

## Test plan
- [x] Hover over chart bars and verify tooltip appears with token count + cost
- [x] Verify tooltip disappears when mouse leaves bar area
- [x] Verify non-hovered bars dim correctly
- [x] Verify tooltip stays within chart bounds on edge bars (first/last)
- [x] Verify cost displays in EUR when locale is French

🤖 Generated with [Claude Code](https://claude.com/claude-code)