### PR TITLE
Update plugin description with cost estimation

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "claudeCodeUsage",
     "name": "Claude Code Usage",
-    "description": "Monitor your Claude Code subscription usage with token tracking, rate limits, and daily activity charts",
+    "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
     "version": "1.1.0",
     "author": "Nicolas Bellamy",
     "icon": "monitoring",


### PR DESCRIPTION
## Summary
- Add "estimated API costs" to the plugin description in plugin.json so the feature is visible in the DMS plugin registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)