### PR TITLE
Fix stale day-of-week labels in daily activity chart

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -15,7 +15,9 @@ PluginComponent {
     function tr(key) { return Tr.tr(key, lang) }
 
     // Rolling 7-day labels (index 0 = 6 days ago, index 6 = today)
+    property int refreshEpoch: 0
     property var dayLabels: {
+        void(refreshEpoch)
         var frDays = ["Di", "Lu", "Ma", "Me", "Je", "Ve", "Sa"]
         var enDays = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
         var days = lang === "fr" ? frDays : enDays
@@ -220,6 +222,7 @@ PluginComponent {
 
         onExited: (exitCode, exitStatus) => {
             root.isLoading = false
+            root.refreshEpoch++
         }
     }
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "claudeCodeUsage",
     "name": "Claude Code Usage",
     "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "author": "Nicolas Bellamy",
     "icon": "monitoring",
     "type": "widget",


### PR DESCRIPTION
## Summary
- `dayLabels` was computed once at widget creation and never re-evaluated, causing day names to become stale after midnight (e.g. showing Thursday when it's actually Sunday)
- Add a `refreshEpoch` counter incremented on each data fetch cycle, referenced in the `dayLabels` binding to force QML re-evaluation
- Labels now stay in sync with the rolling 7-day token/cost data

## Test plan
- [ ] Let the widget run past midnight and verify the day labels update correctly
- [ ] Confirm the last column always shows today's abbreviated day name

🤖 Generated with [Claude Code](https://claude.com/claude-code)