### PR TITLE
Add tests and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: .
+          additional_files: get-claude-usage
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run tests
+        run: |
+          chmod +x tests/*.sh
+          for t in tests/test-*.sh; do bash "$t"; done

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -24,7 +24,7 @@ PluginComponent {
         var labels = []
         var now = new Date()
         for (var i = 6; i >= 0; i--) {
-            var d = new Date(now.getTime() - i * 86400000)
+            var d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i)
             labels.push(days[d.getDay()])
         }
         return labels
@@ -221,8 +221,10 @@ PluginComponent {
         }
 
         onExited: (exitCode, exitStatus) => {
-            root.isLoading = false
-            root.refreshEpoch++
+            if (exitCode === 0) {
+                root.isLoading = false
+                root.refreshEpoch++
+            }
         }
     }
 

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -70,14 +70,14 @@ refresh_pricing() {
     local eur_rate
     eur_rate=$(curl -s --max-time 5 "https://api.frankfurter.app/latest?from=USD&to=EUR" 2>/dev/null \
         | jq -r '.rates.EUR // empty' 2>/dev/null) || eur_rate=""
-    if [ -n "$eur_rate" ]; then
+    if [ -n "$eur_rate" ] && [[ "$eur_rate" =~ ^[0-9]+\.?[0-9]*$ ]]; then
         result=$(echo "$result" | jq -c '. + {usd_eur_rate: '"$eur_rate"'}' 2>/dev/null)
     fi
 
-    # Validate that we got actual prices
+    # Validate that we got at least one model with pricing
     local check
-    check=$(echo "$result" | jq -r '.models.opus.input // empty' 2>/dev/null) || return 1
-    [ -n "$check" ] && echo "$result" > "$PRICING_CACHE" && return 0
+    check=$(echo "$result" | jq -r '.models | to_entries | length' 2>/dev/null) || return 1
+    [ "$check" -gt 0 ] 2>/dev/null && echo "$result" > "$PRICING_CACHE" && return 0
     return 1
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -9,7 +9,7 @@
     "capabilities": ["dankbar-widget"],
     "component": "./ClaudeCodeUsageWidget.qml",
     "settings": "./ClaudeCodeUsageSettings.qml",
-    "requires": ["jq"],
+    "requires": ["jq", "curl"],
     "permissions": [
         "settings_read",
         "settings_write"

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -185,11 +185,13 @@ cat > "$ENV6/.claude/pricing-cache.json" << 'EUREOF'
 EUREOF
 
 OUTPUT6=$(run_script "$ENV6")
-EUR_RATE=$(echo "$OUTPUT6" | grep "^USD_EUR_RATE=" | cut -d= -f2)
 # The script reads usd_eur_rate from JSON as-is via jq; the QML side validates.
-# But USD_EUR_RATE should still be set (the script doesn't re-validate cached values)
-# What matters is that it doesn't crash.
-pass "Script runs with non-numeric EUR rate without crashing"
+# What matters is that it doesn't crash and still produces output.
+if echo "$OUTPUT6" | grep -q "^USD_EUR_RATE="; then
+    pass "Script runs with non-numeric EUR rate without crashing"
+else
+    fail "Script crashed or missing USD_EUR_RATE with non-numeric EUR rate"
+fi
 
 # ============================================================
 echo "=== Test 7: Pricing validation — cache without opus family ==="

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Tests for get-claude-usage script
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/get-claude-usage"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+assert_eq() {
+    if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+assert_match() {
+    if echo "$1" | grep -qE "$2"; then pass "$3"; else fail "$3 (no match for '$2')"; fi
+}
+
+# --- Setup isolated environment ---
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+setup_env() {
+    local name="$1"
+    local dir="$TMPDIR_ROOT/$name"
+    mkdir -p "$dir/.claude/projects/test-project"
+    echo "$dir"
+}
+
+# Mock curl: always returns empty JSON (avoids real network calls)
+mock_curl="$TMPDIR_ROOT/curl"
+cat > "$mock_curl" << 'CURLEOF'
+#!/usr/bin/env bash
+echo '{}'
+CURLEOF
+chmod +x "$mock_curl"
+
+run_script() {
+    local home_dir="$1"
+    # Override HOME and prepend mock curl to PATH
+    HOME="$home_dir" PATH="$TMPDIR_ROOT:$PATH" bash "$SCRIPT" 2>/dev/null
+}
+
+# Build a JSONL fixture line
+# Usage: make_jsonl_line <date> <model> <input> <output> <cache_read> <cache_write> <sessionId>
+make_jsonl_line() {
+    local date="$1" model="$2" inp="$3" out="$4" cr="$5" cw="$6" sess="$7"
+    printf '{"type":"assistant","timestamp":"%sT12:00:00Z","sessionId":"%s","message":{"model":"%s","usage":{"input_tokens":%d,"output_tokens":%d,"cache_read_input_tokens":%d,"cache_creation_input_tokens":%d}}}\n' \
+        "$date" "$sess" "$model" "$inp" "$out" "$cr" "$cw"
+}
+
+# ============================================================
+echo "=== Test 1: Output format — all 21 keys present ==="
+# ============================================================
+ENV1=$(setup_env "test1")
+OUTPUT1=$(run_script "$ENV1")
+
+EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
+for key in $EXPECTED_KEYS; do
+    if echo "$OUTPUT1" | grep -q "^${key}="; then
+        pass "key $key present"
+    else
+        fail "key $key missing"
+    fi
+done
+
+# ============================================================
+echo "=== Test 2: Token aggregation ==="
+# ============================================================
+ENV2=$(setup_env "test2")
+TODAY=$(date +%Y-%m-%d)
+YESTERDAY=$(date -d "1 day ago" +%Y-%m-%d)
+
+# Create JSONL fixtures: 2 messages today (session A), 1 message yesterday (session B)
+{
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 100 200 50 30 "sess-a"
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 150 100 0 0 "sess-a"
+    make_jsonl_line "$YESTERDAY" "claude-sonnet-4-20250514" 80 60 20 10 "sess-b"
+} > "$ENV2/.claude/projects/test-project/test.jsonl"
+
+OUTPUT2=$(run_script "$ENV2")
+
+# Total tokens: (100+200+50+30) + (150+100+0+0) + (80+60+20+10) = 380+250+170 = 800
+WEEK_TOKENS=$(echo "$OUTPUT2" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$WEEK_TOKENS" "800" "WEEK_TOKENS=800"
+
+# 3 messages total
+WEEK_MESSAGES=$(echo "$OUTPUT2" | grep "^WEEK_MESSAGES=" | cut -d= -f2)
+assert_eq "$WEEK_MESSAGES" "3" "WEEK_MESSAGES=3"
+
+# 2 sessions
+WEEK_SESSIONS=$(echo "$OUTPUT2" | grep "^WEEK_SESSIONS=" | cut -d= -f2)
+assert_eq "$WEEK_SESSIONS" "2" "WEEK_SESSIONS=2"
+
+# WEEK_MODELS should contain opus and sonnet
+WEEK_MODELS=$(echo "$OUTPUT2" | grep "^WEEK_MODELS=" | cut -d= -f2)
+assert_match "$WEEK_MODELS" "opus" "WEEK_MODELS contains opus"
+assert_match "$WEEK_MODELS" "sonnet" "WEEK_MODELS contains sonnet"
+
+# DAILY: last value (today) should be 630 (380+250), second-to-last should be 170
+DAILY=$(echo "$OUTPUT2" | grep "^DAILY=" | cut -d= -f2)
+DAILY_TODAY=$(echo "$DAILY" | tr ',' '\n' | tail -1)
+DAILY_YESTERDAY=$(echo "$DAILY" | tr ',' '\n' | tail -2 | head -1)
+assert_eq "$DAILY_TODAY" "630" "DAILY today=630"
+assert_eq "$DAILY_YESTERDAY" "170" "DAILY yesterday=170"
+
+# ============================================================
+echo "=== Test 3: Cost calculation ==="
+# ============================================================
+ENV3=$(setup_env "test3")
+
+# Write a pricing cache with known prices
+# opus: input=0.000015, output=0.000075, cache_read=0.0000015, cache_write=0.00001875
+cat > "$ENV3/.claude/pricing-cache.json" << PRICEEOF
+{
+    "updated": "$(date +%Y-%m-%d)",
+    "models": {
+        "opus": {"input": 0.000015, "output": 0.000075, "cache_read": 0.0000015, "cache_write": 0.00001875}
+    },
+    "usd_eur_rate": 0.92
+}
+PRICEEOF
+
+# One message today: 1000 input, 500 output, 200 cache_read, 100 cache_write
+{
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 1000 500 200 100 "sess-c"
+} > "$ENV3/.claude/projects/test-project/test.jsonl"
+
+OUTPUT3=$(run_script "$ENV3")
+
+# Expected cost: 1000*0.000015 + 500*0.000075 + 200*0.0000015 + 100*0.00001875
+# = 0.015 + 0.0375 + 0.0003 + 0.001875 = 0.054675
+TODAY_COST=$(echo "$OUTPUT3" | grep "^TODAY_COST=" | cut -d= -f2)
+assert_eq "$TODAY_COST" "0.05" "TODAY_COST=0.05 (rounded)"
+
+WEEK_COST=$(echo "$OUTPUT3" | grep "^WEEK_COST=" | cut -d= -f2)
+assert_eq "$WEEK_COST" "0.05" "WEEK_COST matches TODAY_COST"
+
+USD_EUR_RATE=$(echo "$OUTPUT3" | grep "^USD_EUR_RATE=" | cut -d= -f2)
+assert_eq "$USD_EUR_RATE" "0.92" "USD_EUR_RATE from cache"
+
+# ============================================================
+echo "=== Test 4: Missing credentials — defaults ==="
+# ============================================================
+ENV4=$(setup_env "test4")
+# No .credentials.json
+OUTPUT4=$(run_script "$ENV4")
+
+SUB_TYPE=$(echo "$OUTPUT4" | grep "^SUBSCRIPTION_TYPE=" | cut -d= -f2)
+assert_eq "$SUB_TYPE" "unknown" "SUBSCRIPTION_TYPE=unknown without credentials"
+
+FIVE_HOUR=$(echo "$OUTPUT4" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)
+assert_eq "$FIVE_HOUR" "0" "FIVE_HOUR_UTIL=0 without credentials"
+
+EXTRA=$(echo "$OUTPUT4" | grep "^EXTRA_USAGE_ENABLED=" | cut -d= -f2)
+assert_eq "$EXTRA" "false" "EXTRA_USAGE_ENABLED=false without credentials"
+
+# ============================================================
+echo "=== Test 5: Empty projects dir — all counters zero ==="
+# ============================================================
+ENV5=$(setup_env "test5")
+# projects dir exists but has no JSONL files
+OUTPUT5=$(run_script "$ENV5")
+
+assert_eq "$(echo "$OUTPUT5" | grep "^WEEK_TOKENS=" | cut -d= -f2)" "0" "WEEK_TOKENS=0 empty"
+assert_eq "$(echo "$OUTPUT5" | grep "^WEEK_MESSAGES=" | cut -d= -f2)" "0" "WEEK_MESSAGES=0 empty"
+assert_eq "$(echo "$OUTPUT5" | grep "^WEEK_SESSIONS=" | cut -d= -f2)" "0" "WEEK_SESSIONS=0 empty"
+assert_eq "$(echo "$OUTPUT5" | grep "^MONTH_TOKENS=" | cut -d= -f2)" "0" "MONTH_TOKENS=0 empty"
+assert_eq "$(echo "$OUTPUT5" | grep "^DAILY=" | cut -d= -f2)" "0,0,0,0,0,0,0" "DAILY all zeros"
+
+# ============================================================
+echo "=== Test 6: EUR rate sanitisation ==="
+# ============================================================
+ENV6=$(setup_env "test6")
+
+# Pricing cache with a non-numeric EUR rate — should be treated as 0
+cat > "$ENV6/.claude/pricing-cache.json" << 'EUREOF'
+{
+    "updated": "2099-12-31",
+    "models": {
+        "opus": {"input": 0.000015, "output": 0.000075, "cache_read": 0.0000015, "cache_write": 0.00001875}
+    },
+    "usd_eur_rate": "not-a-number"
+}
+EUREOF
+
+OUTPUT6=$(run_script "$ENV6")
+EUR_RATE=$(echo "$OUTPUT6" | grep "^USD_EUR_RATE=" | cut -d= -f2)
+# The script reads usd_eur_rate from JSON as-is via jq; the QML side validates.
+# But USD_EUR_RATE should still be set (the script doesn't re-validate cached values)
+# What matters is that it doesn't crash.
+pass "Script runs with non-numeric EUR rate without crashing"
+
+# ============================================================
+echo "=== Test 7: Pricing validation — cache without opus family ==="
+# ============================================================
+ENV7=$(setup_env "test7")
+
+# Pricing cache with only "haiku" — no opus family
+cat > "$ENV7/.claude/pricing-cache.json" << 'PVEOF'
+{
+    "updated": "2099-12-31",
+    "models": {
+        "haiku": {"input": 0.0000008, "output": 0.000004, "cache_read": 0.00000008, "cache_write": 0.000001}
+    }
+}
+PVEOF
+
+# Message with an opus model — should not crash, cost should be 0 (no pricing match)
+{
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 1000 500 0 0 "sess-d"
+} > "$ENV7/.claude/projects/test-project/test.jsonl"
+
+OUTPUT7=$(run_script "$ENV7")
+TODAY_COST7=$(echo "$OUTPUT7" | grep "^TODAY_COST=" | cut -d= -f2)
+assert_eq "$TODAY_COST7" "0.00" "Cost=0 when model family not in pricing cache"
+
+# ============================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-plugin-json.sh
+++ b/tests/test-plugin-json.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tests for plugin.json validation
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLUGIN_JSON="$SCRIPT_DIR/plugin.json"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+echo "=== Test 1: JSON is valid ==="
+if jq empty "$PLUGIN_JSON" 2>/dev/null; then
+    pass "plugin.json is valid JSON"
+else
+    fail "plugin.json is not valid JSON"
+fi
+
+echo "=== Test 2: Required fields present ==="
+for field in id name version type component; do
+    val=$(jq -r ".$field // empty" "$PLUGIN_JSON")
+    if [ -n "$val" ]; then
+        pass "field '$field' present ($val)"
+    else
+        fail "field '$field' missing or empty"
+    fi
+done
+
+echo "=== Test 3: Requires contains jq and curl ==="
+REQUIRES=$(jq -r '.requires[]' "$PLUGIN_JSON" 2>/dev/null)
+for dep in jq curl; do
+    if echo "$REQUIRES" | grep -qx "$dep"; then
+        pass "requires contains '$dep'"
+    else
+        fail "requires missing '$dep'"
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-qml-syntax.sh
+++ b/tests/test-qml-syntax.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tests for QML file syntax validation
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+QML_FILES=$(find "$SCRIPT_DIR" -maxdepth 1 -name "*.qml" -type f)
+
+echo "=== Test 1: QML files exist and are not empty ==="
+if [ -z "$QML_FILES" ]; then
+    fail "No .qml files found"
+else
+    for f in $QML_FILES; do
+        name=$(basename "$f")
+        if [ -s "$f" ]; then
+            pass "$name exists and is not empty"
+        else
+            fail "$name is empty"
+        fi
+    done
+fi
+
+echo "=== Test 2: Required imports ==="
+for f in $QML_FILES; do
+    name=$(basename "$f")
+    if grep -q "^import QtQuick" "$f"; then
+        pass "$name imports QtQuick"
+    else
+        fail "$name missing 'import QtQuick'"
+    fi
+done
+
+echo "=== Test 3: No hardcoded millisecond date arithmetic ==="
+for f in $QML_FILES; do
+    name=$(basename "$f")
+    # 86400000 in date offset arithmetic (e.g. "new Date() - 86400000") is fragile.
+    # Using it for duration formatting (remaining / 86400000) is acceptable.
+    if grep "86400000" "$f" | grep -qvE '(remaining|elapsed|duration|diff)'; then
+        fail "$name uses 86400000 outside duration formatting"
+    else
+        pass "$name no problematic 86400000 usage"
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Add bash test suite for `get-claude-usage` (7 scenarios, 41 assertions): output format, token aggregation, cost calculation, missing credentials, empty projects, EUR rate sanitisation, pricing validation
- Add `plugin.json` validation tests (valid JSON, required fields, required dependencies)
- Add QML syntax checks (file existence, imports, no problematic magic numbers)
- Add GitHub Actions CI workflow with ShellCheck and test execution
- Fix EUR exchange rate validation with regex guard
- Use model count instead of hardcoded opus check for pricing validation
- Add `curl` to `plugin.json` requires
- Fix stale day labels using `Date` constructor instead of ms arithmetic
- Only clear loading state on successful script exit

## Test plan
- [x] `bash tests/test-get-claude-usage.sh` — 41 passed, 0 failed
- [x] `bash tests/test-plugin-json.sh` — 8 passed, 0 failed
- [x] `bash tests/test-qml-syntax.sh` — 6 passed, 0 failed
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)