### PR TITLE
Fix version-bump: remove non-existent label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,4 @@ jobs:
 
           gh pr create \
             --title "Bump version to ${new_version}" \
-            --body "Automated patch version bump: \`${current}\` → \`${new_version}\`" \
-            --label "automated"
+            --body "Automated patch version bump: \`${current}\` → \`${new_version}\`"


### PR DESCRIPTION
## Summary
- Remove `--label "automated"` from `gh pr create` — the label doesn't exist in the repo, causing the command to fail even though the branch was pushed successfully

## Test plan
- [ ] CI passes
- [ ] After merge, the version-bump job should successfully create a bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)