### PR TITLE
Fix version-bump loop on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           for t in tests/test-*.sh; do bash "$t"; done
 
   version-bump:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'Bump version to ')
     needs: [shellcheck, tests]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip the `version-bump` job when the head commit message starts with "Bump version to " to prevent infinite bump loops

## Test plan
- [ ] CI passes
- [ ] After merge, the version-bump job creates a bump PR
- [ ] Merging that bump PR does NOT create another bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)