### PR TITLE
Only bump version when source files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,27 @@ jobs:
           chmod +x tests/*.sh
           for t in tests/test-*.sh; do bash "$t"; done
 
-  version-bump:
+  check-source-changes:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'Bump version to ')
-    needs: [shellcheck, tests]
+    runs-on: ubuntu-latest
+    outputs:
+      has_source_changes: ${{ steps.changes.outputs.has_source_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Check for source file changes
+        id: changes
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^(get-claude-usage|.*\.qml|translations\.js|plugin\.json)$'; then
+            echo "has_source_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_source_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  version-bump:
+    needs: [shellcheck, tests, check-source-changes]
+    if: needs.check-source-changes.outputs.has_source_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add a `check-source-changes` job that detects if source files were modified in the last commit
- The `version-bump` job now only runs when `get-claude-usage`, `*.qml`, `translations.js` or `plugin.json` change
- CI-only, docs, or test-only merges no longer create a bump PR

## Test plan
- [ ] CI passes
- [ ] After merge (CI-only change), no bump PR is created
- [ ] Future source file changes still trigger a bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)