### PR TITLE
Fix stale data after sleep, settings crash, and add tests

### DIFF
--- a/ClaudeCodeUsageSettings.qml
+++ b/ClaudeCodeUsageSettings.qml
@@ -34,7 +34,7 @@ PluginSettings {
         defaultValue: 2
         minimum: 2
         maximum: 15
-        stepSize: 1
+
         unit: "min"
         leftIcon: "schedule"
     }

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -63,7 +63,7 @@ PluginComponent {
 
     // Today's index in the calendar week (0=Monday, 6=Sunday)
     property int todayIndex: {
-        void(refreshEpoch)
+        void(countdownNow)
         var dow = new Date().getDay() // 0=Sunday, 6=Saturday
         return dow === 0 ? 6 : dow - 1
     }
@@ -102,7 +102,15 @@ PluginComponent {
         running: true
         repeat: true
         triggeredOnStart: true
-        onTriggered: root.countdownNow = Date.now()
+        onTriggered: {
+            var now = Date.now()
+            var elapsed = now - root.countdownNow
+            root.countdownNow = now
+            // Large gap (>2min) indicates wake from sleep — force immediate refresh
+            if (elapsed > 120000 && !usageProcess.running) {
+                usageProcess.running = true
+            }
+        }
     }
 
     // Script path via PluginService

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -229,6 +229,279 @@ TODAY_COST7=$(echo "$OUTPUT7" | grep "^TODAY_COST=" | cut -d= -f2)
 assert_eq "$TODAY_COST7" "0.00" "Cost=0 when model family not in pricing cache"
 
 # ============================================================
+echo "=== Test 8: Week boundary — previous week data excluded from WEEK_TOKENS ==="
+# ============================================================
+ENV8=$(setup_env "test8")
+
+# Compute last Sunday (always before current week which starts Monday)
+LAST_SUNDAY=$(date -d "last Sunday" +%Y-%m-%d)
+# If today IS Sunday, "last Sunday" is today; go back 7 more days
+if [ "$(date +%u)" -eq 7 ]; then
+    LAST_SUNDAY=$(date -d "7 days ago" +%Y-%m-%d)
+fi
+
+{
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 100 100 0 0 "sess-w1"
+    make_jsonl_line "$LAST_SUNDAY" "claude-sonnet-4-20250514" 500 500 0 0 "sess-w2"
+} > "$ENV8/.claude/projects/test-project/test.jsonl"
+
+OUTPUT8=$(run_script "$ENV8")
+WEEK_TOKENS8=$(echo "$OUTPUT8" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$WEEK_TOKENS8" "200" "Previous week data excluded from WEEK_TOKENS"
+
+# Previous week data should still count toward MONTH_TOKENS if same month
+MONTH_TOKENS8=$(echo "$OUTPUT8" | grep "^MONTH_TOKENS=" | cut -d= -f2)
+LAST_SUNDAY_MONTH=$(date -d "$LAST_SUNDAY" +%Y-%m)
+CURRENT_MONTH=$(date +%Y-%m)
+if [ "$LAST_SUNDAY_MONTH" = "$CURRENT_MONTH" ]; then
+    assert_eq "$MONTH_TOKENS8" "1200" "Previous week same-month data included in MONTH_TOKENS"
+else
+    assert_eq "$MONTH_TOKENS8" "200" "Previous month data excluded from MONTH_TOKENS"
+fi
+
+# ============================================================
+echo "=== Test 9: Month boundary — previous month data excluded ==="
+# ============================================================
+ENV9=$(setup_env "test9")
+
+# Use a date from the previous month
+PREV_MONTH_DATE=$(date -d "$(date +%Y-%m-01) - 1 day" +%Y-%m-%d)
+
+{
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 100 100 0 0 "sess-m1"
+    make_jsonl_line "$PREV_MONTH_DATE" "claude-sonnet-4-20250514" 400 400 0 0 "sess-m2"
+} > "$ENV9/.claude/projects/test-project/test.jsonl"
+
+OUTPUT9=$(run_script "$ENV9")
+MONTH_TOKENS9=$(echo "$OUTPUT9" | grep "^MONTH_TOKENS=" | cut -d= -f2)
+assert_eq "$MONTH_TOKENS9" "200" "Previous month data excluded from MONTH_TOKENS"
+
+# ============================================================
+echo "=== Test 10: Malformed JSONL lines are skipped ==="
+# ============================================================
+ENV10=$(setup_env "test10")
+
+{
+    echo "this is not json"
+    echo ""
+    echo '{"truncated": true'
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 100 100 0 0 "sess-mf"
+    echo '{"type":"assistant","timestamp":"invalid"}'
+} > "$ENV10/.claude/projects/test-project/test.jsonl"
+
+OUTPUT10=$(run_script "$ENV10")
+WEEK_TOKENS10=$(echo "$OUTPUT10" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$WEEK_TOKENS10" "200" "Malformed lines skipped, valid line counted"
+
+# ============================================================
+echo "=== Test 11: Non-assistant types excluded ==="
+# ============================================================
+ENV11=$(setup_env "test11")
+
+{
+    # User message — should be ignored
+    printf '{"type":"user","timestamp":"%sT12:00:00Z","sessionId":"sess-u","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":999,"output_tokens":999,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n' "$TODAY"
+    # Tool message — should be ignored
+    printf '{"type":"tool","timestamp":"%sT12:00:00Z","sessionId":"sess-t","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":888,"output_tokens":888,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n' "$TODAY"
+    # Valid assistant message
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 50 50 0 0 "sess-a"
+} > "$ENV11/.claude/projects/test-project/test.jsonl"
+
+OUTPUT11=$(run_script "$ENV11")
+WEEK_TOKENS11=$(echo "$OUTPUT11" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$WEEK_TOKENS11" "100" "Only assistant messages counted"
+WEEK_MESSAGES11=$(echo "$OUTPUT11" | grep "^WEEK_MESSAGES=" | cut -d= -f2)
+assert_eq "$WEEK_MESSAGES11" "1" "Non-assistant messages excluded from count"
+
+# ============================================================
+echo "=== Test 12: Multiple projects aggregated ==="
+# ============================================================
+ENV12=$(setup_env "test12")
+mkdir -p "$ENV12/.claude/projects/project-a"
+mkdir -p "$ENV12/.claude/projects/project-b"
+
+{
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 100 100 0 0 "sess-pa"
+} > "$ENV12/.claude/projects/project-a/log.jsonl"
+{
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 200 200 0 0 "sess-pb"
+} > "$ENV12/.claude/projects/project-b/log.jsonl"
+
+OUTPUT12=$(run_script "$ENV12")
+WEEK_TOKENS12=$(echo "$OUTPUT12" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$WEEK_TOKENS12" "600" "Tokens from multiple projects aggregated"
+WEEK_SESSIONS12=$(echo "$OUTPUT12" | grep "^WEEK_SESSIONS=" | cut -d= -f2)
+assert_eq "$WEEK_SESSIONS12" "2" "Sessions from multiple projects counted"
+
+# ============================================================
+echo "=== Test 13: Usage API cache — fresh cache used ==="
+# ============================================================
+ENV13=$(setup_env "test13")
+
+# Create credentials so the API path is entered
+cat > "$ENV13/.claude/.credentials.json" << 'CREDEOF'
+{
+    "claudeAiOauth": {
+        "subscriptionType": "pro",
+        "rateLimitTier": "t1_pro",
+        "accessToken": "fake-token"
+    }
+}
+CREDEOF
+
+# Create fresh usage cache (cached_at = now)
+NOW_TS=$(date +%s)
+cat > "$ENV13/.claude/usage-cache.json" << CACHEEOF
+{
+    "cached_at": $NOW_TS,
+    "data": {
+        "five_hour": {"utilization": 42, "resets_at": "2099-01-01T00:00:00Z"},
+        "seven_day": {"utilization": 15, "resets_at": "2099-01-07T00:00:00Z"},
+        "extra_usage": {"is_enabled": true}
+    }
+}
+CACHEEOF
+
+OUTPUT13=$(run_script "$ENV13")
+FIVE13=$(echo "$OUTPUT13" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)
+assert_eq "$FIVE13" "42" "Fresh cache: FIVE_HOUR_UTIL from cache"
+SEVEN13=$(echo "$OUTPUT13" | grep "^SEVEN_DAY_UTIL=" | cut -d= -f2)
+assert_eq "$SEVEN13" "15" "Fresh cache: SEVEN_DAY_UTIL from cache"
+EXTRA13=$(echo "$OUTPUT13" | grep "^EXTRA_USAGE_ENABLED=" | cut -d= -f2)
+assert_eq "$EXTRA13" "true" "Fresh cache: EXTRA_USAGE_ENABLED from cache"
+
+# ============================================================
+echo "=== Test 14: Stats cache parsing ==="
+# ============================================================
+ENV14=$(setup_env "test14")
+
+cat > "$ENV14/.claude/stats-cache.json" << 'STATSEOF'
+{
+    "totalSessions": 150,
+    "totalMessages": 4200,
+    "firstSessionDate": "2024-06-15T10:30:00Z"
+}
+STATSEOF
+
+OUTPUT14=$(run_script "$ENV14")
+AT_SESS14=$(echo "$OUTPUT14" | grep "^ALLTIME_SESSIONS=" | cut -d= -f2)
+assert_eq "$AT_SESS14" "150" "Stats cache: ALLTIME_SESSIONS"
+AT_MSGS14=$(echo "$OUTPUT14" | grep "^ALLTIME_MESSAGES=" | cut -d= -f2)
+assert_eq "$AT_MSGS14" "4200" "Stats cache: ALLTIME_MESSAGES"
+FIRST14=$(echo "$OUTPUT14" | grep "^FIRST_SESSION=" | cut -d= -f2)
+assert_eq "$FIRST14" "2024-06-15" "Stats cache: ISO timestamp T-suffix stripped"
+
+# ============================================================
+echo "=== Test 15: Cost with multiple model families ==="
+# ============================================================
+ENV15=$(setup_env "test15")
+
+cat > "$ENV15/.claude/pricing-cache.json" << MPEOF
+{
+    "updated": "$(date +%Y-%m-%d)",
+    "models": {
+        "opus": {"input": 0.000015, "output": 0.000075, "cache_read": 0, "cache_write": 0},
+        "sonnet": {"input": 0.000003, "output": 0.000015, "cache_read": 0, "cache_write": 0}
+    }
+}
+MPEOF
+
+{
+    make_jsonl_line "$TODAY" "claude-opus-4-20250514" 1000 1000 0 0 "sess-mp1"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 1000 1000 0 0 "sess-mp2"
+} > "$ENV15/.claude/projects/test-project/test.jsonl"
+
+OUTPUT15=$(run_script "$ENV15")
+# opus: 1000*0.000015 + 1000*0.000075 = 0.015 + 0.075 = 0.09
+# sonnet: 1000*0.000003 + 1000*0.000015 = 0.003 + 0.015 = 0.018
+# total: 0.108
+TODAY_COST15=$(echo "$OUTPUT15" | grep "^TODAY_COST=" | cut -d= -f2)
+assert_eq "$TODAY_COST15" "0.11" "Multi-model cost summed correctly"
+
+# ============================================================
+echo "=== Test 16: Pricing cache without EUR rate — USD_EUR_RATE=0 ==="
+# ============================================================
+ENV16=$(setup_env "test16")
+
+cat > "$ENV16/.claude/pricing-cache.json" << 'NOEUREOF'
+{
+    "updated": "2099-12-31",
+    "models": {
+        "sonnet": {"input": 0.000003, "output": 0.000015, "cache_read": 0, "cache_write": 0}
+    }
+}
+NOEUREOF
+
+OUTPUT16=$(run_script "$ENV16")
+EUR16=$(echo "$OUTPUT16" | grep "^USD_EUR_RATE=" | cut -d= -f2)
+assert_eq "$EUR16" "0" "Missing usd_eur_rate defaults to 0"
+
+# ============================================================
+echo "=== Test 17: Session deduplication — same session counted once ==="
+# ============================================================
+ENV17=$(setup_env "test17")
+
+{
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 10 10 0 0 "same-sess"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 20 20 0 0 "same-sess"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 30 30 0 0 "same-sess"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 40 40 0 0 "other-sess"
+} > "$ENV17/.claude/projects/test-project/test.jsonl"
+
+OUTPUT17=$(run_script "$ENV17")
+WEEK_SESSIONS17=$(echo "$OUTPUT17" | grep "^WEEK_SESSIONS=" | cut -d= -f2)
+assert_eq "$WEEK_SESSIONS17" "2" "Same sessionId counted as 1 session"
+WEEK_MESSAGES17=$(echo "$OUTPUT17" | grep "^WEEK_MESSAGES=" | cut -d= -f2)
+assert_eq "$WEEK_MESSAGES17" "4" "All messages counted regardless of session"
+
+# ============================================================
+echo "=== Test 18: DAILY_COSTS aligns with DAILY indices ==="
+# ============================================================
+ENV18=$(setup_env "test18")
+
+cat > "$ENV18/.claude/pricing-cache.json" << DCEOF
+{
+    "updated": "$(date +%Y-%m-%d)",
+    "models": {
+        "sonnet": {"input": 0.000003, "output": 0.000015, "cache_read": 0, "cache_write": 0}
+    }
+}
+DCEOF
+
+{
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 1000 1000 0 0 "sess-dc"
+} > "$ENV18/.claude/projects/test-project/test.jsonl"
+
+OUTPUT18=$(run_script "$ENV18")
+DAILY18=$(echo "$OUTPUT18" | grep "^DAILY=" | cut -d= -f2)
+DAILY_COSTS18=$(echo "$OUTPUT18" | grep "^DAILY_COSTS=" | cut -d= -f2)
+
+# Today's index in calendar week
+TODAY_IDX18=$((DOW - 1))
+
+# Verify tokens and costs are at the same index
+DAILY_TOK=$(echo "$DAILY18" | tr ',' '\n' | sed -n "$((TODAY_IDX18 + 1))p")
+DAILY_CST=$(echo "$DAILY_COSTS18" | tr ',' '\n' | sed -n "$((TODAY_IDX18 + 1))p")
+assert_eq "$DAILY_TOK" "2000" "DAILY tokens at today's index"
+if [ "$DAILY_CST" != "0" ] && [ "$DAILY_CST" != "0.00" ]; then
+    pass "DAILY_COSTS at today's index is non-zero"
+else
+    fail "DAILY_COSTS at today's index should be non-zero (got '$DAILY_CST')"
+fi
+
+# Verify all other indices are zero
+for i in $(seq 0 6); do
+    if [ "$i" -ne "$TODAY_IDX18" ]; then
+        val=$(echo "$DAILY_COSTS18" | tr ',' '\n' | sed -n "$((i + 1))p")
+        if [ "$val" = "0.00" ] || [ "$val" = "0" ]; then
+            pass "DAILY_COSTS[$i] is zero (not today)"
+        else
+            fail "DAILY_COSTS[$i] should be zero, got '$val'"
+        fi
+    fi
+done
+
+# ============================================================
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -3,8 +3,6 @@
 # Extracts pure JS functions from ClaudeCodeUsageWidget.qml and tests them via Node.js
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-
 # Check for Node.js
 if ! command -v node >/dev/null 2>&1; then
     echo "SKIP: Node.js not available, skipping QML function tests"

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# Tests for QML widget JavaScript functions
+# Extracts pure JS functions from ClaudeCodeUsageWidget.qml and tests them via Node.js
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Check for Node.js
+if ! command -v node >/dev/null 2>&1; then
+    echo "SKIP: Node.js not available, skipping QML function tests"
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+# Run a JS expression and capture stdout
+run_js() {
+    node -e "$1" 2>/dev/null
+}
+
+# Build JS test harness with functions extracted from the QML widget
+JS_HARNESS='
+// --- Functions extracted from ClaudeCodeUsageWidget.qml ---
+
+function formatTokens(n) {
+    if (n >= 1000000000) return (n / 1000000000).toFixed(1) + "B"
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + "M"
+    if (n >= 1000) return (n / 1000).toFixed(1) + "K"
+    return Math.round(n).toString()
+}
+
+function shortModelName(name) {
+    if (!name || name.length === 0) return name
+    return name.charAt(0).toUpperCase() + name.slice(1)
+}
+
+function progressColor(pct) {
+    if (pct > 80) return "error"
+    if (pct > 50) return "warning"
+    return "primary"
+}
+
+function formatTier(tier) {
+    if (tier.indexOf("max_20x") >= 0) return "Max 20x"
+    if (tier.indexOf("max_5x") >= 0) return "Max 5x"
+    if (tier.indexOf("pro") >= 0) return "Pro"
+    if (tier.indexOf("free") >= 0) return "Free"
+    return tier
+}
+
+function formatCost(usd, lang, usdEurRate) {
+    var useEur = lang === "fr" && usdEurRate > 0
+    var n = useEur ? usd * usdEurRate : usd
+    var sym = useEur ? "" : "$"
+    var suffix = useEur ? " €" : ""
+    if (n >= 1000) return sym + (n / 1000).toFixed(1) + "K" + suffix
+    if (n >= 100) return sym + Math.round(n) + suffix
+    if (n >= 10) return sym + n.toFixed(1) + suffix
+    return sym + n.toFixed(2) + suffix
+}
+
+function todayIndex() {
+    var dow = new Date().getDay() // 0=Sunday, 6=Saturday
+    return dow === 0 ? 6 : dow - 1
+}
+
+// parseLine: simulates the QML property-setting logic
+function parseLine(line, state) {
+    var idx = line.indexOf("=")
+    if (idx < 0) return state
+    var key = line.substring(0, idx)
+    var val = line.substring(idx + 1)
+
+    switch (key) {
+    case "SUBSCRIPTION_TYPE": state.subscriptionType = val; break
+    case "RATE_LIMIT_TIER": state.rateLimitTier = val; break
+    case "FIVE_HOUR_UTIL": state.fiveHourUtil = parseFloat(val) || 0; break
+    case "FIVE_HOUR_RESET": state.fiveHourReset = val; break
+    case "SEVEN_DAY_UTIL": state.sevenDayUtil = parseFloat(val) || 0; break
+    case "SEVEN_DAY_RESET": state.sevenDayReset = val; break
+    case "EXTRA_USAGE_ENABLED": state.extraUsageEnabled = (val === "true"); break
+    case "WEEK_MESSAGES": state.weekMessages = parseInt(val) || 0; break
+    case "WEEK_SESSIONS": state.weekSessions = parseInt(val) || 0; break
+    case "WEEK_TOKENS": state.weekTokens = parseFloat(val) || 0; break
+    case "MONTH_TOKENS": state.monthTokens = parseFloat(val) || 0; break
+    case "ALLTIME_SESSIONS": state.alltimeSessions = parseInt(val) || 0; break
+    case "ALLTIME_MESSAGES": state.alltimeMessages = parseInt(val) || 0; break
+    case "FIRST_SESSION": state.firstSession = val; break
+    case "WEEK_MODELS":
+        state.models = []
+        if (val.length > 0) {
+            var pairs = val.split(",")
+            for (var i = 0; i < pairs.length; i++) {
+                var kv = pairs[i].split(":")
+                if (kv.length === 2)
+                    state.models.push({ modelName: kv[0], modelTokens: parseInt(kv[1]) || 0 })
+            }
+        }
+        break
+    case "DAILY":
+        var parts = val.split(",")
+        var arr = []
+        for (var j = 0; j < 7; j++)
+            arr.push(j < parts.length ? (parseFloat(parts[j]) || 0) : 0)
+        state.dailyTokens = arr
+        break
+    case "TODAY_COST": state.todayCost = parseFloat(val) || 0; break
+    case "WEEK_COST": state.weekCost = parseFloat(val) || 0; break
+    case "MONTH_COST": state.monthCost = parseFloat(val) || 0; break
+    case "USD_EUR_RATE": state.usdEurRate = parseFloat(val) || 0; break
+    case "DAILY_COSTS":
+        var cparts = val.split(",")
+        var carr = []
+        for (var k = 0; k < 7; k++)
+            carr.push(k < cparts.length ? (parseFloat(cparts[k]) || 0) : 0)
+        state.dailyCosts = carr
+        break
+    }
+    return state
+}
+'
+
+# ============================================================
+echo "=== Test 1: formatTokens ==="
+# ============================================================
+
+test_format_tokens() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(run_js "${JS_HARNESS} console.log(formatTokens($input))")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+test_format_tokens 0 "0" "formatTokens(0) = 0"
+test_format_tokens 1 "1" "formatTokens(1) = 1"
+test_format_tokens 999 "999" "formatTokens(999) = 999"
+test_format_tokens 1000 "1.0K" "formatTokens(1000) = 1.0K"
+test_format_tokens 1500 "1.5K" "formatTokens(1500) = 1.5K"
+test_format_tokens 999999 "1000.0K" "formatTokens(999999) = 1000.0K"
+test_format_tokens 1000000 "1.0M" "formatTokens(1M) = 1.0M"
+test_format_tokens 1500000 "1.5M" "formatTokens(1.5M) = 1.5M"
+test_format_tokens 1000000000 "1.0B" "formatTokens(1B) = 1.0B"
+test_format_tokens 2500000000 "2.5B" "formatTokens(2.5B) = 2.5B"
+
+# ============================================================
+echo "=== Test 2: shortModelName ==="
+# ============================================================
+
+test_short_model() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(run_js "${JS_HARNESS} console.log(shortModelName('$input'))")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+test_short_model "opus" "Opus" "shortModelName(opus) = Opus"
+test_short_model "sonnet" "Sonnet" "shortModelName(sonnet) = Sonnet"
+test_short_model "haiku" "Haiku" "shortModelName(haiku) = Haiku"
+test_short_model "a" "A" "shortModelName(a) = A"
+
+# Empty/null cases
+RESULT_EMPTY=$(run_js "${JS_HARNESS} console.log(shortModelName(''))")
+if [ "$RESULT_EMPTY" = "" ]; then pass "shortModelName('') = empty"; else fail "shortModelName('') expected empty, got '$RESULT_EMPTY'"; fi
+
+RESULT_NULL=$(run_js "${JS_HARNESS} console.log(shortModelName(null))")
+if [ "$RESULT_NULL" = "null" ]; then pass "shortModelName(null) = null"; else fail "shortModelName(null) expected null, got '$RESULT_NULL'"; fi
+
+# ============================================================
+echo "=== Test 3: progressColor ==="
+# ============================================================
+
+test_progress_color() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(run_js "${JS_HARNESS} console.log(progressColor($input))")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+test_progress_color 0 "primary" "progressColor(0) = primary"
+test_progress_color 50 "primary" "progressColor(50) = primary"
+test_progress_color 51 "warning" "progressColor(51) = warning"
+test_progress_color 80 "warning" "progressColor(80) = warning"
+test_progress_color 81 "error" "progressColor(81) = error"
+test_progress_color 100 "error" "progressColor(100) = error"
+
+# ============================================================
+echo "=== Test 4: formatTier ==="
+# ============================================================
+
+test_format_tier() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(run_js "${JS_HARNESS} console.log(formatTier('$input'))")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+test_format_tier "t3_max_20x_something" "Max 20x" "formatTier max_20x"
+test_format_tier "t2_max_5x_something" "Max 5x" "formatTier max_5x"
+test_format_tier "t1_pro_something" "Pro" "formatTier pro"
+test_format_tier "free_tier" "Free" "formatTier free"
+test_format_tier "unknown" "unknown" "formatTier unknown passthrough"
+test_format_tier "custom_plan" "custom_plan" "formatTier unrecognised passthrough"
+
+# ============================================================
+echo "=== Test 5: formatCost ==="
+# ============================================================
+
+test_format_cost() {
+    local usd="$1" lang="$2" rate="$3" expected="$4" label="$5"
+    local result
+    result=$(run_js "${JS_HARNESS} console.log(formatCost($usd, '$lang', $rate))")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+# USD mode (non-French locale)
+test_format_cost 0 "en" 0 "\$0.00" "formatCost(0) USD = \$0.00"
+test_format_cost 5.5 "en" 0 "\$5.50" "formatCost(5.5) USD = \$5.50"
+test_format_cost 15.3 "en" 0 "\$15.3" "formatCost(15.3) USD = \$15.3"
+test_format_cost 150 "en" 0 "\$150" "formatCost(150) USD = \$150"
+test_format_cost 1500 "en" 0 "\$1.5K" "formatCost(1500) USD = \$1.5K"
+
+# EUR mode (French locale with rate)
+test_format_cost 10 "fr" 0.92 "9.20 €" "formatCost(10) EUR = 9.20 €"
+test_format_cost 100 "fr" 0.92 "92.0 €" "formatCost(100) EUR = 92.0 € (92<100 → toFixed(1))"
+test_format_cost 1500 "fr" 0.92 "1.4K €" "formatCost(1500) EUR = 1.4K €"
+
+# French locale but rate=0 → falls back to USD
+test_format_cost 5 "fr" 0 "\$5.00" "formatCost(5) FR no rate = USD fallback"
+
+# ============================================================
+echo "=== Test 6: todayIndex ==="
+# ============================================================
+
+# todayIndex should match: Monday=0, Tuesday=1, ..., Sunday=6
+EXPECTED_INDEX=$(date +%u)  # 1=Monday, 7=Sunday
+EXPECTED_INDEX=$((EXPECTED_INDEX - 1))  # 0=Monday, 6=Sunday
+ACTUAL_INDEX=$(run_js "${JS_HARNESS} console.log(todayIndex())")
+
+if [ "$ACTUAL_INDEX" = "$EXPECTED_INDEX" ]; then
+    pass "todayIndex() = $EXPECTED_INDEX (matches today)"
+else
+    fail "todayIndex() expected $EXPECTED_INDEX, got $ACTUAL_INDEX"
+fi
+
+# Test specific days via mocking
+test_today_index_mock() {
+    local js_dow="$1" expected="$2" label="$3"
+    local result
+    result=$(run_js "
+        var _getDay = Date.prototype.getDay;
+        Date.prototype.getDay = function() { return $js_dow; };
+        ${JS_HARNESS}
+        console.log(todayIndex());
+        Date.prototype.getDay = _getDay;
+    ")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+test_today_index_mock 0 6 "todayIndex Sunday (getDay=0) → 6"
+test_today_index_mock 1 0 "todayIndex Monday (getDay=1) → 0"
+test_today_index_mock 2 1 "todayIndex Tuesday (getDay=2) → 1"
+test_today_index_mock 3 2 "todayIndex Wednesday (getDay=3) → 2"
+test_today_index_mock 4 3 "todayIndex Thursday (getDay=4) → 3"
+test_today_index_mock 5 4 "todayIndex Friday (getDay=5) → 4"
+test_today_index_mock 6 5 "todayIndex Saturday (getDay=6) → 5"
+
+# ============================================================
+echo "=== Test 7: parseLine ==="
+# ============================================================
+
+test_parse_line() {
+    local input="$1" field="$2" expected="$3" label="$4"
+    local result
+    result=$(run_js "${JS_HARNESS}
+        var s = {};
+        parseLine('$input', s);
+        console.log(typeof s.$field === 'undefined' ? 'UNDEFINED' : JSON.stringify(s.$field));
+    ")
+    if [ "$result" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$result')"
+    fi
+}
+
+# Basic key=value parsing
+test_parse_line "SUBSCRIPTION_TYPE=pro" "subscriptionType" '"pro"' "parseLine SUBSCRIPTION_TYPE"
+test_parse_line "FIVE_HOUR_UTIL=42.5" "fiveHourUtil" '42.5' "parseLine FIVE_HOUR_UTIL float"
+test_parse_line "WEEK_MESSAGES=100" "weekMessages" '100' "parseLine WEEK_MESSAGES int"
+test_parse_line "EXTRA_USAGE_ENABLED=true" "extraUsageEnabled" 'true' "parseLine EXTRA_USAGE bool true"
+test_parse_line "EXTRA_USAGE_ENABLED=false" "extraUsageEnabled" 'false' "parseLine EXTRA_USAGE bool false"
+
+# Empty values default to 0
+test_parse_line "WEEK_TOKENS=" "weekTokens" '0' "parseLine empty value defaults to 0"
+test_parse_line "FIVE_HOUR_UTIL=" "fiveHourUtil" '0' "parseLine empty float defaults to 0"
+
+# No equals sign — ignored
+RESULT_NOEQUALS=$(run_js "${JS_HARNESS}
+    var s = { weekTokens: 99 };
+    parseLine('GARBAGE', s);
+    console.log(s.weekTokens);
+")
+if [ "$RESULT_NOEQUALS" = "99" ]; then
+    pass "parseLine no equals sign is ignored"
+else
+    fail "parseLine no equals sign should be ignored (got weekTokens=$RESULT_NOEQUALS)"
+fi
+
+# DAILY with fewer than 7 values — padded with zeros
+RESULT_SHORT=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('DAILY=100,200', s);
+    console.log(JSON.stringify(s.dailyTokens));
+")
+if [ "$RESULT_SHORT" = "[100,200,0,0,0,0,0]" ]; then
+    pass "parseLine DAILY short array padded to 7"
+else
+    fail "parseLine DAILY short array expected [100,200,0,0,0,0,0], got $RESULT_SHORT"
+fi
+
+# DAILY with 7 values
+RESULT_FULL=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('DAILY=1,2,3,4,5,6,7', s);
+    console.log(JSON.stringify(s.dailyTokens));
+")
+if [ "$RESULT_FULL" = "[1,2,3,4,5,6,7]" ]; then
+    pass "parseLine DAILY full 7 values"
+else
+    fail "parseLine DAILY full expected [1,2,3,4,5,6,7], got $RESULT_FULL"
+fi
+
+# DAILY_COSTS with fewer than 7 values
+RESULT_COSTS_SHORT=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('DAILY_COSTS=0.50,1.20', s);
+    console.log(JSON.stringify(s.dailyCosts));
+")
+if [ "$RESULT_COSTS_SHORT" = "[0.5,1.2,0,0,0,0,0]" ]; then
+    pass "parseLine DAILY_COSTS short array padded to 7"
+else
+    fail "parseLine DAILY_COSTS short expected [0.5,1.2,0,0,0,0,0], got $RESULT_COSTS_SHORT"
+fi
+
+# WEEK_MODELS with valid pairs
+RESULT_MODELS=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('WEEK_MODELS=opus:5000,sonnet:3000', s);
+    console.log(JSON.stringify(s.models));
+")
+if [ "$RESULT_MODELS" = '[{"modelName":"opus","modelTokens":5000},{"modelName":"sonnet","modelTokens":3000}]' ]; then
+    pass "parseLine WEEK_MODELS valid pairs"
+else
+    fail "parseLine WEEK_MODELS expected [{opus,5000},{sonnet,3000}], got $RESULT_MODELS"
+fi
+
+# WEEK_MODELS empty value
+RESULT_MODELS_EMPTY=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('WEEK_MODELS=', s);
+    console.log(JSON.stringify(s.models));
+")
+if [ "$RESULT_MODELS_EMPTY" = "[]" ]; then
+    pass "parseLine WEEK_MODELS empty = empty array"
+else
+    fail "parseLine WEEK_MODELS empty expected [], got $RESULT_MODELS_EMPTY"
+fi
+
+# WEEK_MODELS with malformed entry (no colon) — skipped
+RESULT_MODELS_BAD=$(run_js "${JS_HARNESS}
+    var s = {};
+    parseLine('WEEK_MODELS=opus:5000,badentry,sonnet:3000', s);
+    console.log(JSON.stringify(s.models));
+")
+if [ "$RESULT_MODELS_BAD" = '[{"modelName":"opus","modelTokens":5000},{"modelName":"sonnet","modelTokens":3000}]' ]; then
+    pass "parseLine WEEK_MODELS malformed entry skipped"
+else
+    fail "parseLine WEEK_MODELS malformed expected opus+sonnet only, got $RESULT_MODELS_BAD"
+fi
+
+# ============================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- **Fix wake-from-sleep bug**: widget now detects sleep/wake (time gap >2min) and triggers immediate refresh instead of showing stale yesterday's data
- **Fix todayIndex**: re-evaluates every minute via `countdownNow` instead of only on script completion, so the day indicator updates correctly after midnight
- **Fix settings crash**: remove unsupported `stepSize` property from `SliderSetting` that prevented the settings page from loading
- **Add comprehensive tests**: 126 assertions covering bash script edge cases and QML JS functions

## Test plan
- [x] All 67 bash script tests pass (18 test groups)
- [x] All 59 QML function tests pass (7 test groups)
- [x] Plugin tested locally on DMS — settings page loads, widget displays correctly
- [ ] Verify wake-from-sleep refresh by suspending and resuming

🤖 Generated with [Claude Code](https://claude.com/claude-code)