### PR TITLE
Support for Claude Code Switcher

### DIFF
--- a/ClaudeCodeUsageSettings.qml
+++ b/ClaudeCodeUsageSettings.qml
@@ -9,7 +9,9 @@ PluginSettings {
     pluginId: "claudeCodeUsage"
 
     property string lang: Qt.locale().name.split(/[_-]/)[0]
-    function tr(key) { return Tr.tr(key, lang) }
+    function tr(key) {
+        return Tr.tr(key, lang);
+    }
 
     StyledText {
         width: parent.width

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -71,55 +71,31 @@ PluginComponent {
     ListModel { id: profileListModel }
     // First entry is always { name: "all" }; populated by PROFILES output field.
 
+    // currentPd is a single reactive snapshot of the selected profile's data object.
+    // Re-evaluated whenever selectedProfile or profileData changes.
+    // All display* properties derive from this — ensures consistent re-evaluation.
+    property var currentPd: {
+        void(selectedProfile); void(profileData)
+        if (selectedProfile === "all") return null
+        return profileData[selectedProfile] || null
+    }
+
     // Computed display values — switch between aggregate and per-profile data.
-    // When selectedProfile === "all" or profile has no data, fall back to aggregates.
-    property real displayFiveHourUtil: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return fiveHourUtil
-        return profileData[selectedProfile].fiveHourUtil || 0
-    }
-    property string displayFiveHourReset: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return fiveHourReset
-        return profileData[selectedProfile].fiveHourReset || ""
-    }
-    property real displaySevenDayUtil: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return sevenDayUtil
-        return profileData[selectedProfile].sevenDayUtil || 0
-    }
-    property string displaySevenDayReset: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return sevenDayReset
-        return profileData[selectedProfile].sevenDayReset || ""
-    }
-    property real displayWeekTokens: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return weekTokens
-        return profileData[selectedProfile].weekTokens || 0
-    }
-    property real displayMonthTokens: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return monthTokens
-        return profileData[selectedProfile].monthTokens || 0
-    }
-    property real displayTodayCost: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return todayCost
-        return profileData[selectedProfile].todayCost || 0
-    }
-    property real displayWeekCost: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return weekCost
-        return profileData[selectedProfile].weekCost || 0
-    }
-    property real displayMonthCost: {
-        if (selectedProfile === "all" || !profileData[selectedProfile]) return monthCost
-        return profileData[selectedProfile].monthCost || 0
-    }
-    property var displayDailyTokens: {
-        if (selectedProfile === "all" || !profileData[selectedProfile] || !profileData[selectedProfile].daily)
-            return dailyTokens
-        return profileData[selectedProfile].daily
-    }
+    property string displaySubscriptionType: currentPd && currentPd.subscriptionType ? currentPd.subscriptionType : subscriptionType
+    property string displayRateLimitTier:    currentPd && currentPd.rateLimitTier    ? currentPd.rateLimitTier    : rateLimitTier
+    property real   displayFiveHourUtil:     currentPd && currentPd.fiveHourUtil  !== undefined ? currentPd.fiveHourUtil  : fiveHourUtil
+    property string displayFiveHourReset:    currentPd && currentPd.fiveHourReset !== undefined ? currentPd.fiveHourReset : fiveHourReset
+    property real   displaySevenDayUtil:     currentPd && currentPd.sevenDayUtil  !== undefined ? currentPd.sevenDayUtil  : sevenDayUtil
+    property string displaySevenDayReset:    currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
+    property real   displayWeekTokens:       currentPd && currentPd.weekTokens    !== undefined ? currentPd.weekTokens    : weekTokens
+    property real   displayMonthTokens:      currentPd && currentPd.monthTokens   !== undefined ? currentPd.monthTokens   : monthTokens
+    property real   displayTodayCost:        currentPd && currentPd.todayCost     !== undefined ? currentPd.todayCost     : todayCost
+    property real   displayWeekCost:         currentPd && currentPd.weekCost      !== undefined ? currentPd.weekCost      : weekCost
+    property real   displayMonthCost:        currentPd && currentPd.monthCost     !== undefined ? currentPd.monthCost     : monthCost
+    property var    displayDailyTokens:      currentPd && currentPd.daily ? currentPd.daily : dailyTokens
+
     // Per-profile daily tokens for chart overlay. Empty array when "all" selected.
-    property var profileDailyTokens: {
-        if (selectedProfile === "all") return []
-        var pd = profileData[selectedProfile]
-        return (pd && pd.daily) ? pd.daily : []
-    }
+    property var profileDailyTokens: currentPd && currentPd.daily ? currentPd.daily : []
 
     // Note: displayDailyCosts is intentionally NOT defined.
     // The tooltip cost line always shows aggregate dailyCosts per spec.
@@ -369,6 +345,10 @@ PluginComponent {
             profileData = parseProfileSimple(val, "weekCost", true); break
         case "PROFILE_MONTH_COST":
             profileData = parseProfileSimple(val, "monthCost", true); break
+        case "PROFILE_SUBSCRIPTION":
+            profileData = parseProfileString(val, "subscriptionType"); break
+        case "PROFILE_TIER":
+            profileData = parseProfileString(val, "rateLimitTier"); break
         case "PROFILE_FIVE_HOUR_UTIL":
             profileData = parseProfileSimple(val, "fiveHourUtil", true); break
         case "PROFILE_SEVEN_DAY_UTIL":
@@ -377,6 +357,8 @@ PluginComponent {
             profileData = parseProfileString(val, "fiveHourReset"); break
         case "PROFILE_SEVEN_DAY_RESET":
             profileData = parseProfileString(val, "sevenDayReset"); break
+        case "PROFILE_EXTRA_USAGE":
+            profileData = parseProfileString(val, "extraUsageEnabled"); break
         case "PROFILE_DAILY": {
             var _pd1 = Object.assign({}, profileData)
             var blocks1 = val.split("|")
@@ -710,7 +692,7 @@ PluginComponent {
         PopoutComponent {
             headerText: root.tr("Claude Code Usage")
             detailsText: {
-                var label = root.formatSubscription(root.subscriptionType, root.rateLimitTier)
+                var label = root.formatSubscription(root.displaySubscriptionType, root.displayRateLimitTier)
                 return label ? root.tr("Subscription") + ": " + label : ""
             }
             showCloseButton: true

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -61,6 +61,16 @@ PluginComponent {
     // Model list
     ListModel { id: modelListData }
 
+    // Profile selector state
+    property string selectedProfile: "all"
+    property var profileData: ({})
+    // Shape per profile: { weekTokens, monthTokens, todayCost, weekCost, monthCost,
+    //   daily:[7], dailyCosts:[7], weekModels:[{modelName,modelTokens}],
+    //   fiveHourUtil, sevenDayUtil, fiveHourReset, sevenDayReset }
+
+    ListModel { id: profileListModel }
+    // First entry is always { name: "all" }; populated by PROFILES output field.
+
     // Today's index in the calendar week (0=Monday, 6=Sunday)
     property int todayIndex: {
         void(refreshEpoch)
@@ -150,6 +160,45 @@ PluginComponent {
         return tier
     }
 
+    // Helper: parse "name:value,name:value,..." into profileData[name][field]
+    // For numeric fields. Full object replacement ensures QML reactivity.
+    function parseProfileSimple(val, field, isFloat) {
+        var _pd = Object.assign({}, profileData)
+        var entries = val.split(",")
+        for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i]
+            var colon = entry.indexOf(":")
+            if (colon < 0) continue
+            var name = entry.substring(0, colon)
+            var v = isFloat
+                ? (parseFloat(entry.substring(colon + 1)) || 0)
+                : (parseInt(entry.substring(colon + 1)) || 0)
+            if (!_pd[name]) _pd[name] = {}
+            _pd[name][field] = v
+        }
+        return _pd
+    }
+
+    // Helper: parse "name:value,..." for string fields (e.g. reset timestamps).
+    // Uses indexOf(":") so ISO 8601 timestamps with colons are handled correctly —
+    // profile names never contain colons, so first colon is always the delimiter.
+    // An empty value after ":" (e.g. "personal:") is intentionally stored as "" —
+    // it is not an error, it means no reset time for that profile.
+    function parseProfileString(val, field) {
+        var _pd = Object.assign({}, profileData)
+        var entries = val.split(",")
+        for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i]
+            var colon = entry.indexOf(":")
+            if (colon < 0) continue
+            var name = entry.substring(0, colon)
+            var v = entry.substring(colon + 1)
+            if (!_pd[name]) _pd[name] = {}
+            _pd[name][field] = v
+        }
+        return _pd
+    }
+
     function parseLine(line) {
         var idx = line.indexOf("=")
         if (idx < 0) return
@@ -174,11 +223,14 @@ PluginComponent {
         case "WEEK_MODELS":
             modelListData.clear()
             if (val.length > 0) {
-                var pairs = val.split(",")
-                for (var i = 0; i < pairs.length; i++) {
-                    var kv = pairs[i].split(":")
-                    if (kv.length === 2)
-                        modelListData.append({ modelName: kv[0], modelTokens: parseInt(kv[1]) || 0 })
+                var wmpairs = val.split(",")
+                for (var wmi = 0; wmi < wmpairs.length; wmi++) {
+                    var wmeq = wmpairs[wmi].indexOf("=")
+                    if (wmeq >= 0)
+                        modelListData.append({
+                            modelName:   wmpairs[wmi].substring(0, wmeq),
+                            modelTokens: parseInt(wmpairs[wmi].substring(wmeq + 1)) || 0
+                        })
                 }
             }
             break
@@ -200,6 +252,104 @@ PluginComponent {
                 carr.push(k < cparts.length ? (parseFloat(cparts[k]) || 0) : 0)
             dailyCosts = carr
             break
+        case "PROFILES": {
+            profileListModel.clear()
+            profileListModel.append({ name: "all" })
+            var profs = val.split(",")
+            for (var pi = 0; pi < profs.length; pi++)
+                profileListModel.append({ name: profs[pi] })
+            // Reset selectedProfile if it no longer exists in new profile list
+            if (selectedProfile !== "all") {
+                var found = false
+                for (var fi = 0; fi < profs.length; fi++)
+                    if (profs[fi] === selectedProfile) { found = true; break }
+                if (!found) selectedProfile = "all"
+            }
+            break
+        }
+        case "PROFILE_WEEK_TOKENS":
+            profileData = parseProfileSimple(val, "weekTokens", false); break
+        case "PROFILE_MONTH_TOKENS":
+            profileData = parseProfileSimple(val, "monthTokens", false); break
+        case "PROFILE_TODAY_COST":
+            profileData = parseProfileSimple(val, "todayCost", true); break
+        case "PROFILE_WEEK_COST":
+            profileData = parseProfileSimple(val, "weekCost", true); break
+        case "PROFILE_MONTH_COST":
+            profileData = parseProfileSimple(val, "monthCost", true); break
+        case "PROFILE_FIVE_HOUR_UTIL":
+            profileData = parseProfileSimple(val, "fiveHourUtil", true); break
+        case "PROFILE_SEVEN_DAY_UTIL":
+            profileData = parseProfileSimple(val, "sevenDayUtil", true); break
+        case "PROFILE_FIVE_HOUR_RESET":
+            profileData = parseProfileString(val, "fiveHourReset"); break
+        case "PROFILE_SEVEN_DAY_RESET":
+            profileData = parseProfileString(val, "sevenDayReset"); break
+        case "PROFILE_DAILY": {
+            var _pd1 = Object.assign({}, profileData)
+            var blocks1 = val.split("|")
+            for (var bi1 = 0; bi1 < blocks1.length; bi1++) {
+                var blk1 = blocks1[bi1]
+                var c1 = blk1.indexOf(":")
+                if (c1 < 0) continue
+                var pname1 = blk1.substring(0, c1)
+                var csv1 = blk1.substring(c1 + 1)
+                if (!_pd1[pname1]) _pd1[pname1] = {}
+                var parts1 = csv1.split(",")
+                var arr1 = []
+                for (var di = 0; di < 7; di++)
+                    arr1.push(di < parts1.length ? (parseFloat(parts1[di]) || 0) : 0)
+                _pd1[pname1].daily = arr1
+            }
+            profileData = _pd1
+            break
+        }
+        case "PROFILE_DAILY_COSTS": {
+            var _pd2 = Object.assign({}, profileData)
+            var blocks2 = val.split("|")
+            for (var bi2 = 0; bi2 < blocks2.length; bi2++) {
+                var blk2 = blocks2[bi2]
+                var c2 = blk2.indexOf(":")
+                if (c2 < 0) continue
+                var pname2 = blk2.substring(0, c2)
+                var csv2 = blk2.substring(c2 + 1)
+                if (!_pd2[pname2]) _pd2[pname2] = {}
+                var parts2 = csv2.split(",")
+                var arr2 = []
+                for (var dci = 0; dci < 7; dci++)
+                    arr2.push(dci < parts2.length ? (parseFloat(parts2[dci]) || 0) : 0)
+                _pd2[pname2].dailyCosts = arr2
+            }
+            profileData = _pd2
+            break
+        }
+        case "PROFILE_WEEK_MODELS": {
+            var _pd3 = Object.assign({}, profileData)
+            var blocks3 = val.split("|")
+            for (var bi3 = 0; bi3 < blocks3.length; bi3++) {
+                var blk3 = blocks3[bi3]
+                var c3 = blk3.indexOf(":")
+                if (c3 < 0) continue
+                var pname3 = blk3.substring(0, c3)
+                var mcsv = blk3.substring(c3 + 1)
+                if (!_pd3[pname3]) _pd3[pname3] = {}
+                var wms = []
+                if (mcsv.length > 0) {
+                    var mentries = mcsv.split(",")
+                    for (var mi = 0; mi < mentries.length; mi++) {
+                        var eq = mentries[mi].indexOf("=")
+                        if (eq < 0) continue
+                        wms.push({
+                            modelName:   mentries[mi].substring(0, eq),
+                            modelTokens: parseInt(mentries[mi].substring(eq + 1)) || 0
+                        })
+                    }
+                }
+                _pd3[pname3].weekModels = wms
+            }
+            profileData = _pd3
+            break
+        }
         }
     }
 
@@ -332,7 +482,7 @@ PluginComponent {
     popoutContent: Component {
         PopoutComponent {
             headerText: root.tr("Claude Code Usage")
-            detailsText: root.rateLimitTier ? root.tr("Subscription") + " : " + root.formatTier(root.rateLimitTier) : ""
+            detailsText: root.rateLimitTier ? root.tr("Subscription") + ": " + root.formatTier(root.rateLimitTier) : ""
             showCloseButton: true
 
             Column {

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -114,6 +114,13 @@ PluginComponent {
             return dailyTokens
         return profileData[selectedProfile].daily
     }
+    // Per-profile daily tokens for chart overlay. Empty array when "all" selected.
+    property var profileDailyTokens: {
+        if (selectedProfile === "all") return []
+        var pd = profileData[selectedProfile]
+        return (pd && pd.daily) ? pd.daily : []
+    }
+
     // Note: displayDailyCosts is intentionally NOT defined.
     // The tooltip cost line always shows aggregate dailyCosts per spec.
     // The Token Consumption card uses displayTodayCost/displayWeekCost/displayMonthCost instead.
@@ -1016,7 +1023,9 @@ PluginComponent {
                                             width: parent.width
                                             height: parent.height - dayLabel.height - 2
 
+                                            // Background bar: total tokens (always shown)
                                             Rectangle {
+                                                id: totalBar
                                                 anchors.bottom: parent.bottom
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 width: Math.max(parent.width - 4, 4)
@@ -1024,9 +1033,27 @@ PluginComponent {
                                                     ? Math.max(root.dailyTokens[index] / root.maxDaily * parent.height, root.dailyTokens[index] > 0 ? 3 : 0)
                                                     : 0
                                                 radius: 2
-                                                color: index === root.hoveredDay
-                                                    ? Theme.primary
-                                                    : index === root.todayIndex ? Theme.primary : Theme.surfaceVariant
+                                                color: root.selectedProfile === "all"
+                                                    ? (index === root.todayIndex ? Theme.primary : Theme.surfaceVariant)
+                                                    : Theme.surfaceVariant
+                                                opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
+
+                                                Behavior on opacity {
+                                                    NumberAnimation { duration: 120 }
+                                                }
+                                            }
+
+                                            // Overlay bar: profile tokens (shown only when a profile is selected)
+                                            Rectangle {
+                                                visible: root.selectedProfile !== "all" && root.profileDailyTokens.length > 0
+                                                anchors.bottom: parent.bottom
+                                                anchors.horizontalCenter: parent.horizontalCenter
+                                                width: Math.max(parent.width - 4, 4)
+                                                height: root.maxDaily > 0 && root.profileDailyTokens.length > index
+                                                    ? Math.max(root.profileDailyTokens[index] / root.maxDaily * parent.height, root.profileDailyTokens[index] > 0 ? 3 : 0)
+                                                    : 0
+                                                radius: 2
+                                                color: Theme.primary
                                                 opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
 
                                                 Behavior on opacity {
@@ -1086,14 +1113,35 @@ PluginComponent {
                             anchors.centerIn: parent
                             spacing: 1
 
+                            // Line 1: total tokens (with "total" suffix when a profile is selected)
                             StyledText {
-                                text: root.hoveredDay >= 0 ? root.formatTokens(root.dailyTokens[root.hoveredDay]) : ""
+                                text: {
+                                    if (root.hoveredDay < 0) return ""
+                                    var t = root.formatTokens(root.dailyTokens[root.hoveredDay])
+                                    return root.selectedProfile !== "all" ? t + " total" : t
+                                }
                                 font.pixelSize: 11
                                 font.weight: Font.DemiBold
                                 color: Theme.surfaceText
                                 anchors.horizontalCenter: parent.horizontalCenter
                             }
 
+                            // Line 2: profile tokens (only when a profile is selected and has data)
+                            StyledText {
+                                visible: root.selectedProfile !== "all"
+                                    && root.hoveredDay >= 0
+                                    && root.profileDailyTokens.length > root.hoveredDay
+                                    && root.profileDailyTokens[root.hoveredDay] > 0
+                                text: {
+                                    if (root.hoveredDay < 0 || root.profileDailyTokens.length <= root.hoveredDay) return ""
+                                    return root.formatTokens(root.profileDailyTokens[root.hoveredDay]) + " " + root.selectedProfile
+                                }
+                                font.pixelSize: 11
+                                color: Theme.primary
+                                anchors.horizontalCenter: parent.horizontalCenter
+                            }
+
+                            // Line 3: total cost (always shown when > 0, uses aggregate dailyCosts)
                             StyledText {
                                 visible: root.hoveredDay >= 0 && root.dailyCosts[root.hoveredDay] > 0
                                 text: root.hoveredDay >= 0 ? root.formatCost(root.dailyCosts[root.hoveredDay]) : ""

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -12,13 +12,13 @@ PluginComponent {
 
     // i18n
     property string lang: Qt.locale().name.split(/[_-]/)[0]
-    function tr(key) { return Tr.tr(key, lang) }
+    function tr(key) {
+        return Tr.tr(key, lang);
+    }
 
     // Calendar week labels: Monday to Sunday (fixed order)
     property int refreshEpoch: 0
-    property var dayLabels: lang === "fr"
-        ? ["Lu", "Ma", "Me", "Je", "Ve", "Sa", "Di"]
-        : ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+    property var dayLabels: lang === "fr" ? ["Lu", "Ma", "Me", "Je", "Ve", "Sa", "Di"] : ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
 
     // Settings
     property int refreshInterval: (pluginData.refreshInterval || 2) * 60000
@@ -59,7 +59,9 @@ PluginComponent {
     property int hoveredDay: -1
 
     // Model list
-    ListModel { id: modelListData }
+    ListModel {
+        id: modelListData
+    }
 
     // Profile selector state
     property string selectedProfile: "all"
@@ -68,31 +70,35 @@ PluginComponent {
     //   daily:[7], dailyCosts:[7], weekModels:[{modelName,modelTokens}],
     //   fiveHourUtil, sevenDayUtil, fiveHourReset, sevenDayReset }
 
-    ListModel { id: profileListModel }
+    ListModel {
+        id: profileListModel
+    }
     // First entry is always { name: "all" }; populated by PROFILES output field.
 
     // currentPd is a single reactive snapshot of the selected profile's data object.
     // Re-evaluated whenever selectedProfile or profileData changes.
     // All display* properties derive from this — ensures consistent re-evaluation.
     property var currentPd: {
-        void(selectedProfile); void(profileData)
-        if (selectedProfile === "all") return null
-        return profileData[selectedProfile] || null
+        void (selectedProfile);
+        void (profileData);
+        if (selectedProfile === "all")
+            return null;
+        return profileData[selectedProfile] || null;
     }
 
     // Computed display values — switch between aggregate and per-profile data.
     property string displaySubscriptionType: currentPd && currentPd.subscriptionType ? currentPd.subscriptionType : subscriptionType
-    property string displayRateLimitTier:    currentPd && currentPd.rateLimitTier    ? currentPd.rateLimitTier    : rateLimitTier
-    property real   displayFiveHourUtil:     currentPd && currentPd.fiveHourUtil  !== undefined ? currentPd.fiveHourUtil  : fiveHourUtil
-    property string displayFiveHourReset:    currentPd && currentPd.fiveHourReset !== undefined ? currentPd.fiveHourReset : fiveHourReset
-    property real   displaySevenDayUtil:     currentPd && currentPd.sevenDayUtil  !== undefined ? currentPd.sevenDayUtil  : sevenDayUtil
-    property string displaySevenDayReset:    currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
-    property real   displayWeekTokens:       currentPd && currentPd.weekTokens    !== undefined ? currentPd.weekTokens    : weekTokens
-    property real   displayMonthTokens:      currentPd && currentPd.monthTokens   !== undefined ? currentPd.monthTokens   : monthTokens
-    property real   displayTodayCost:        currentPd && currentPd.todayCost     !== undefined ? currentPd.todayCost     : todayCost
-    property real   displayWeekCost:         currentPd && currentPd.weekCost      !== undefined ? currentPd.weekCost      : weekCost
-    property real   displayMonthCost:        currentPd && currentPd.monthCost     !== undefined ? currentPd.monthCost     : monthCost
-    property var    displayDailyTokens:      currentPd && currentPd.daily ? currentPd.daily : dailyTokens
+    property string displayRateLimitTier: currentPd && currentPd.rateLimitTier ? currentPd.rateLimitTier : rateLimitTier
+    property real displayFiveHourUtil: currentPd && currentPd.fiveHourUtil !== undefined ? currentPd.fiveHourUtil : fiveHourUtil
+    property string displayFiveHourReset: currentPd && currentPd.fiveHourReset !== undefined ? currentPd.fiveHourReset : fiveHourReset
+    property real displaySevenDayUtil: currentPd && currentPd.sevenDayUtil !== undefined ? currentPd.sevenDayUtil : sevenDayUtil
+    property string displaySevenDayReset: currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
+    property real displayWeekTokens: currentPd && currentPd.weekTokens !== undefined ? currentPd.weekTokens : weekTokens
+    property real displayMonthTokens: currentPd && currentPd.monthTokens !== undefined ? currentPd.monthTokens : monthTokens
+    property real displayTodayCost: currentPd && currentPd.todayCost !== undefined ? currentPd.todayCost : todayCost
+    property real displayWeekCost: currentPd && currentPd.weekCost !== undefined ? currentPd.weekCost : weekCost
+    property real displayMonthCost: currentPd && currentPd.monthCost !== undefined ? currentPd.monthCost : monthCost
+    property var displayDailyTokens: currentPd && currentPd.daily ? currentPd.daily : dailyTokens
 
     // Per-profile daily tokens for chart overlay. Empty array when "all" selected.
     property var profileDailyTokens: currentPd && currentPd.daily ? currentPd.daily : []
@@ -102,32 +108,37 @@ PluginComponent {
     // The Token Consumption card uses displayTodayCost/displayWeekCost/displayMonthCost instead.
 
     property string displayFiveHourCountdown: {
-        if (!displayFiveHourReset) return ""
-        var resetMs = new Date(displayFiveHourReset).getTime()
-        var remaining = Math.max(0, resetMs - countdownNow)
-        if (remaining <= 0) return tr("Resetting...")
-        var hours = Math.floor(remaining / 3600000)
-        var mins = Math.floor((remaining % 3600000) / 60000)
-        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+        if (!displayFiveHourReset)
+            return "";
+        var resetMs = new Date(displayFiveHourReset).getTime();
+        var remaining = Math.max(0, resetMs - countdownNow);
+        if (remaining <= 0)
+            return tr("Resetting...");
+        var hours = Math.floor(remaining / 3600000);
+        var mins = Math.floor((remaining % 3600000) / 60000);
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
     }
 
     property string displaySevenDayCountdown: {
-        if (!displaySevenDayReset) return ""
-        var resetMs = new Date(displaySevenDayReset).getTime()
-        var remaining = Math.max(0, resetMs - countdownNow)
-        if (remaining <= 0) return tr("Resetting...")
-        var days = Math.floor(remaining / 86400000)
-        var hours = Math.floor((remaining % 86400000) / 3600000)
-        var mins = Math.floor((remaining % 3600000) / 60000)
-        if (days > 0) return days + "d " + hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
-        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+        if (!displaySevenDayReset)
+            return "";
+        var resetMs = new Date(displaySevenDayReset).getTime();
+        var remaining = Math.max(0, resetMs - countdownNow);
+        if (remaining <= 0)
+            return tr("Resetting...");
+        var days = Math.floor(remaining / 86400000);
+        var hours = Math.floor((remaining % 86400000) / 3600000);
+        var mins = Math.floor((remaining % 3600000) / 60000);
+        if (days > 0)
+            return days + "d " + hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
     }
 
     // Today's index in the calendar week (0=Monday, 6=Sunday)
     property int todayIndex: {
-        void(countdownNow)
-        var dow = new Date().getDay() // 0=Sunday, 6=Saturday
-        return dow === 0 ? 6 : dow - 1
+        void (countdownNow);
+        var dow = new Date().getDay(); // 0=Sunday, 6=Saturday
+        return dow === 0 ? 6 : dow - 1;
     }
 
     // Derived
@@ -138,25 +149,30 @@ PluginComponent {
     property real countdownNow: Date.now()
 
     property string fiveHourCountdown: {
-        if (!fiveHourReset) return ""
-        var resetMs = new Date(fiveHourReset).getTime()
-        var remaining = Math.max(0, resetMs - countdownNow)
-        if (remaining <= 0) return tr("Resetting...")
-        var hours = Math.floor(remaining / 3600000)
-        var mins = Math.floor((remaining % 3600000) / 60000)
-        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+        if (!fiveHourReset)
+            return "";
+        var resetMs = new Date(fiveHourReset).getTime();
+        var remaining = Math.max(0, resetMs - countdownNow);
+        if (remaining <= 0)
+            return tr("Resetting...");
+        var hours = Math.floor(remaining / 3600000);
+        var mins = Math.floor((remaining % 3600000) / 60000);
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
     }
 
     property string sevenDayCountdown: {
-        if (!sevenDayReset) return ""
-        var resetMs = new Date(sevenDayReset).getTime()
-        var remaining = Math.max(0, resetMs - countdownNow)
-        if (remaining <= 0) return tr("Resetting...")
-        var days = Math.floor(remaining / 86400000)
-        var hours = Math.floor((remaining % 86400000) / 3600000)
-        var mins = Math.floor((remaining % 3600000) / 60000)
-        if (days > 0) return days + "d " + hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
-        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+        if (!sevenDayReset)
+            return "";
+        var resetMs = new Date(sevenDayReset).getTime();
+        var remaining = Math.max(0, resetMs - countdownNow);
+        if (remaining <= 0)
+            return tr("Resetting...");
+        var days = Math.floor(remaining / 86400000);
+        var hours = Math.floor((remaining % 86400000) / 3600000);
+        var mins = Math.floor((remaining % 3600000) / 60000);
+        if (days > 0)
+            return days + "d " + hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m";
     }
 
     Timer {
@@ -165,12 +181,12 @@ PluginComponent {
         repeat: true
         triggeredOnStart: true
         onTriggered: {
-            var now = Date.now()
-            var elapsed = now - root.countdownNow
-            root.countdownNow = now
+            var now = Date.now();
+            var elapsed = now - root.countdownNow;
+            root.countdownNow = now;
             // Large gap (>2min) indicates wake from sleep — force immediate refresh
             if (elapsed > 120000 && !usageProcess.running) {
-                usageProcess.running = true
+                usageProcess.running = true;
             }
         }
     }
@@ -184,75 +200,96 @@ PluginComponent {
     // --- Helpers ---
 
     function formatTokens(n) {
-        if (n >= 1000000000) return (n / 1000000000).toFixed(1) + "B"
-        if (n >= 1000000) return (n / 1000000).toFixed(1) + "M"
-        if (n >= 1000) return (n / 1000).toFixed(1) + "K"
-        return Math.round(n).toString()
+        if (n >= 1000000000)
+            return (n / 1000000000).toFixed(1) + "B";
+        if (n >= 1000000)
+            return (n / 1000000).toFixed(1) + "M";
+        if (n >= 1000)
+            return (n / 1000).toFixed(1) + "K";
+        return Math.round(n).toString();
     }
 
     function shortModelName(name) {
-        if (!name || name.length === 0) return name
-        return name.charAt(0).toUpperCase() + name.slice(1)
+        if (!name || name.length === 0)
+            return name;
+        return name.charAt(0).toUpperCase() + name.slice(1);
     }
 
     function progressColor(pct) {
-        if (pct > 80) return Theme.error
-        if (pct > 50) return Theme.warning
-        return Theme.primary
+        if (pct > 80)
+            return Theme.error;
+        if (pct > 50)
+            return Theme.warning;
+        return Theme.primary;
     }
 
     function formatCost(usd) {
-        var useEur = lang === "fr" && usdEurRate > 0
-        var n = useEur ? usd * usdEurRate : usd
-        var sym = useEur ? "" : "$"
-        var suffix = useEur ? " €" : ""
-        if (n >= 1000) return sym + (n / 1000).toFixed(1) + "K" + suffix
-        if (n >= 100) return sym + Math.round(n) + suffix
-        if (n >= 10) return sym + n.toFixed(1) + suffix
-        return sym + n.toFixed(2) + suffix
+        var useEur = lang === "fr" && usdEurRate > 0;
+        var n = useEur ? usd * usdEurRate : usd;
+        var sym = useEur ? "" : "$";
+        var suffix = useEur ? " €" : "";
+        if (n >= 1000)
+            return sym + (n / 1000).toFixed(1) + "K" + suffix;
+        if (n >= 100)
+            return sym + Math.round(n) + suffix;
+        if (n >= 10)
+            return sym + n.toFixed(1) + suffix;
+        return sym + n.toFixed(2) + suffix;
     }
 
     function formatTier(tier) {
-        if (!tier || tier === "unknown") return ""
-        if (tier.indexOf("max_20x") >= 0) return "Max 20x"
-        if (tier.indexOf("max_5x") >= 0) return "Max 5x"
-        if (tier.indexOf("max") >= 0) return "Max"
-        if (tier.indexOf("pro") >= 0) return "Pro"
-        if (tier.indexOf("free") >= 0) return "Free"
-        if (tier.indexOf("team") >= 0) return "Team"
-        if (tier.indexOf("enterprise") >= 0) return "Enterprise"
-        return tier.replace(/_/g, " ").replace(/\b\w/g, function(c) { return c.toUpperCase() })
+        if (!tier || tier === "unknown")
+            return "";
+        if (tier.indexOf("max_20x") >= 0)
+            return "Max 20x";
+        if (tier.indexOf("max_5x") >= 0)
+            return "Max 5x";
+        if (tier.indexOf("max") >= 0)
+            return "Max";
+        if (tier.indexOf("pro") >= 0)
+            return "Pro";
+        if (tier.indexOf("free") >= 0)
+            return "Free";
+        if (tier.indexOf("team") >= 0)
+            return "Team";
+        if (tier.indexOf("enterprise") >= 0)
+            return "Enterprise";
+        return tier.replace(/_/g, " ").replace(/\b\w/g, function (c) {
+            return c.toUpperCase();
+        });
     }
 
     function formatSubscription(subType, tier) {
-        var tierLabel = formatTier(tier)
-        if (!subType || subType === "unknown") return tierLabel
+        var tierLabel = formatTier(tier);
+        if (!subType || subType === "unknown")
+            return tierLabel;
         // Normalize subscriptionType like "claude_pro" → "Pro", "claude_max" → "Max"
-        var subLabel = subType.replace(/^claude[_-]?/i, "")
-                              .replace(/_/g, " ")
-                              .replace(/\b\w/g, function(c) { return c.toUpperCase() })
+        var subLabel = subType.replace(/^claude[_-]?/i, "").replace(/_/g, " ").replace(/\b\w/g, function (c) {
+            return c.toUpperCase();
+        });
         // Prefer tier label if it adds info beyond subType
-        if (tierLabel && tierLabel !== subLabel) return subLabel + " · " + tierLabel
-        return subLabel || tierLabel
+        if (tierLabel && tierLabel !== subLabel)
+            return subLabel + " · " + tierLabel;
+        return subLabel || tierLabel;
     }
 
     // Helper: parse "name:value,name:value,..." into profileData[name][field]
     // For numeric fields. Full object replacement ensures QML reactivity.
     function parseProfileSimple(val, field, isFloat) {
-        var _pd = Object.assign({}, profileData)
-        var entries = val.split(",")
+        var _pd = Object.assign({}, profileData);
+        var entries = val.split(",");
         for (var i = 0; i < entries.length; i++) {
-            var entry = entries[i]
-            var colon = entry.indexOf(":")
-            if (colon < 0) continue
-            var name = entry.substring(0, colon)
-            var v = isFloat
-                ? (parseFloat(entry.substring(colon + 1)) || 0)
-                : (parseInt(entry.substring(colon + 1)) || 0)
-            if (!_pd[name]) _pd[name] = {}
-            _pd[name][field] = v
+            var entry = entries[i];
+            var colon = entry.indexOf(":");
+            if (colon < 0)
+                continue;
+            var name = entry.substring(0, colon);
+            var v = isFloat ? (parseFloat(entry.substring(colon + 1)) || 0) : (parseInt(entry.substring(colon + 1)) || 0);
+            if (!_pd[name])
+                _pd[name] = {};
+            _pd[name][field] = v;
         }
-        return _pd
+        return _pd;
     }
 
     // Helper: parse "name:value,..." for string fields (e.g. reset timestamps).
@@ -261,177 +298,247 @@ PluginComponent {
     // An empty value after ":" (e.g. "personal:") is intentionally stored as "" —
     // it is not an error, it means no reset time for that profile.
     function parseProfileString(val, field) {
-        var _pd = Object.assign({}, profileData)
-        var entries = val.split(",")
+        var _pd = Object.assign({}, profileData);
+        var entries = val.split(",");
         for (var i = 0; i < entries.length; i++) {
-            var entry = entries[i]
-            var colon = entry.indexOf(":")
-            if (colon < 0) continue
-            var name = entry.substring(0, colon)
-            var v = entry.substring(colon + 1)
-            if (!_pd[name]) _pd[name] = {}
-            _pd[name][field] = v
+            var entry = entries[i];
+            var colon = entry.indexOf(":");
+            if (colon < 0)
+                continue;
+            var name = entry.substring(0, colon);
+            var v = entry.substring(colon + 1);
+            if (!_pd[name])
+                _pd[name] = {};
+            _pd[name][field] = v;
         }
-        return _pd
+        return _pd;
     }
 
     function parseLine(line) {
-        var idx = line.indexOf("=")
-        if (idx < 0) return
-        var key = line.substring(0, idx)
-        var val = line.substring(idx + 1)
+        var idx = line.indexOf("=");
+        if (idx < 0)
+            return;
+        var key = line.substring(0, idx);
+        var val = line.substring(idx + 1);
 
         switch (key) {
-        case "SUBSCRIPTION_TYPE": subscriptionType = val; break
-        case "RATE_LIMIT_TIER": rateLimitTier = val; break
-        case "FIVE_HOUR_UTIL": fiveHourUtil = parseFloat(val) || 0; break
-        case "FIVE_HOUR_RESET": fiveHourReset = val; break
-        case "SEVEN_DAY_UTIL": sevenDayUtil = parseFloat(val) || 0; break
-        case "SEVEN_DAY_RESET": sevenDayReset = val; break
-        case "EXTRA_USAGE_ENABLED": extraUsageEnabled = (val === "true"); break
-        case "WEEK_MESSAGES": weekMessages = parseInt(val) || 0; break
-        case "WEEK_SESSIONS": weekSessions = parseInt(val) || 0; break
-        case "WEEK_TOKENS": weekTokens = parseFloat(val) || 0; break
-        case "MONTH_TOKENS": monthTokens = parseFloat(val) || 0; break
-        case "ALLTIME_SESSIONS": alltimeSessions = parseInt(val) || 0; break
-        case "ALLTIME_MESSAGES": alltimeMessages = parseInt(val) || 0; break
-        case "FIRST_SESSION": firstSession = val; break
+        case "SUBSCRIPTION_TYPE":
+            subscriptionType = val;
+            break;
+        case "RATE_LIMIT_TIER":
+            rateLimitTier = val;
+            break;
+        case "FIVE_HOUR_UTIL":
+            fiveHourUtil = parseFloat(val) || 0;
+            break;
+        case "FIVE_HOUR_RESET":
+            fiveHourReset = val;
+            break;
+        case "SEVEN_DAY_UTIL":
+            sevenDayUtil = parseFloat(val) || 0;
+            break;
+        case "SEVEN_DAY_RESET":
+            sevenDayReset = val;
+            break;
+        case "EXTRA_USAGE_ENABLED":
+            extraUsageEnabled = (val === "true");
+            break;
+        case "WEEK_MESSAGES":
+            weekMessages = parseInt(val) || 0;
+            break;
+        case "WEEK_SESSIONS":
+            weekSessions = parseInt(val) || 0;
+            break;
+        case "WEEK_TOKENS":
+            weekTokens = parseFloat(val) || 0;
+            break;
+        case "MONTH_TOKENS":
+            monthTokens = parseFloat(val) || 0;
+            break;
+        case "ALLTIME_SESSIONS":
+            alltimeSessions = parseInt(val) || 0;
+            break;
+        case "ALLTIME_MESSAGES":
+            alltimeMessages = parseInt(val) || 0;
+            break;
+        case "FIRST_SESSION":
+            firstSession = val;
+            break;
         case "WEEK_MODELS":
-            modelListData.clear()
+            modelListData.clear();
             if (val.length > 0) {
-                var wmpairs = val.split(",")
+                var wmpairs = val.split(",");
                 for (var wmi = 0; wmi < wmpairs.length; wmi++) {
-                    var wmeq = wmpairs[wmi].indexOf("=")
+                    var wmeq = wmpairs[wmi].indexOf("=");
                     if (wmeq >= 0)
                         modelListData.append({
-                            modelName:   wmpairs[wmi].substring(0, wmeq),
+                            modelName: wmpairs[wmi].substring(0, wmeq),
                             modelTokens: parseInt(wmpairs[wmi].substring(wmeq + 1)) || 0
-                        })
+                        });
                 }
             }
-            break
+            break;
         case "DAILY":
-            var parts = val.split(",")
-            var arr = []
+            var parts = val.split(",");
+            var arr = [];
             for (var j = 0; j < 7; j++)
-                arr.push(j < parts.length ? (parseFloat(parts[j]) || 0) : 0)
-            dailyTokens = arr
-            break
-        case "TODAY_COST": todayCost = parseFloat(val) || 0; break
-        case "WEEK_COST": weekCost = parseFloat(val) || 0; break
-        case "MONTH_COST": monthCost = parseFloat(val) || 0; break
-        case "USD_EUR_RATE": usdEurRate = parseFloat(val) || 0; break
+                arr.push(j < parts.length ? (parseFloat(parts[j]) || 0) : 0);
+            dailyTokens = arr;
+            break;
+        case "TODAY_COST":
+            todayCost = parseFloat(val) || 0;
+            break;
+        case "WEEK_COST":
+            weekCost = parseFloat(val) || 0;
+            break;
+        case "MONTH_COST":
+            monthCost = parseFloat(val) || 0;
+            break;
+        case "USD_EUR_RATE":
+            usdEurRate = parseFloat(val) || 0;
+            break;
         case "DAILY_COSTS":
-            var cparts = val.split(",")
-            var carr = []
+            var cparts = val.split(",");
+            var carr = [];
             for (var k = 0; k < 7; k++)
-                carr.push(k < cparts.length ? (parseFloat(cparts[k]) || 0) : 0)
-            dailyCosts = carr
-            break
-        case "PROFILES": {
-            profileListModel.clear()
-            profileListModel.append({ name: "all" })
-            var profs = val.split(",")
-            for (var pi = 0; pi < profs.length; pi++)
-                profileListModel.append({ name: profs[pi] })
-            // Reset selectedProfile if it no longer exists in new profile list
-            if (selectedProfile !== "all") {
-                var found = false
-                for (var fi = 0; fi < profs.length; fi++)
-                    if (profs[fi] === selectedProfile) { found = true; break }
-                if (!found) selectedProfile = "all"
-            }
-            break
-        }
-        case "PROFILE_WEEK_TOKENS":
-            profileData = parseProfileSimple(val, "weekTokens", false); break
-        case "PROFILE_MONTH_TOKENS":
-            profileData = parseProfileSimple(val, "monthTokens", false); break
-        case "PROFILE_TODAY_COST":
-            profileData = parseProfileSimple(val, "todayCost", true); break
-        case "PROFILE_WEEK_COST":
-            profileData = parseProfileSimple(val, "weekCost", true); break
-        case "PROFILE_MONTH_COST":
-            profileData = parseProfileSimple(val, "monthCost", true); break
-        case "PROFILE_SUBSCRIPTION":
-            profileData = parseProfileString(val, "subscriptionType"); break
-        case "PROFILE_TIER":
-            profileData = parseProfileString(val, "rateLimitTier"); break
-        case "PROFILE_FIVE_HOUR_UTIL":
-            profileData = parseProfileSimple(val, "fiveHourUtil", true); break
-        case "PROFILE_SEVEN_DAY_UTIL":
-            profileData = parseProfileSimple(val, "sevenDayUtil", true); break
-        case "PROFILE_FIVE_HOUR_RESET":
-            profileData = parseProfileString(val, "fiveHourReset"); break
-        case "PROFILE_SEVEN_DAY_RESET":
-            profileData = parseProfileString(val, "sevenDayReset"); break
-        case "PROFILE_EXTRA_USAGE":
-            profileData = parseProfileString(val, "extraUsageEnabled"); break
-        case "PROFILE_DAILY": {
-            var _pd1 = Object.assign({}, profileData)
-            var blocks1 = val.split("|")
-            for (var bi1 = 0; bi1 < blocks1.length; bi1++) {
-                var blk1 = blocks1[bi1]
-                var c1 = blk1.indexOf(":")
-                if (c1 < 0) continue
-                var pname1 = blk1.substring(0, c1)
-                var csv1 = blk1.substring(c1 + 1)
-                if (!_pd1[pname1]) _pd1[pname1] = {}
-                var parts1 = csv1.split(",")
-                var arr1 = []
-                for (var di = 0; di < 7; di++)
-                    arr1.push(di < parts1.length ? (parseFloat(parts1[di]) || 0) : 0)
-                _pd1[pname1].daily = arr1
-            }
-            profileData = _pd1
-            break
-        }
-        case "PROFILE_DAILY_COSTS": {
-            var _pd2 = Object.assign({}, profileData)
-            var blocks2 = val.split("|")
-            for (var bi2 = 0; bi2 < blocks2.length; bi2++) {
-                var blk2 = blocks2[bi2]
-                var c2 = blk2.indexOf(":")
-                if (c2 < 0) continue
-                var pname2 = blk2.substring(0, c2)
-                var csv2 = blk2.substring(c2 + 1)
-                if (!_pd2[pname2]) _pd2[pname2] = {}
-                var parts2 = csv2.split(",")
-                var arr2 = []
-                for (var dci = 0; dci < 7; dci++)
-                    arr2.push(dci < parts2.length ? (parseFloat(parts2[dci]) || 0) : 0)
-                _pd2[pname2].dailyCosts = arr2
-            }
-            profileData = _pd2
-            break
-        }
-        case "PROFILE_WEEK_MODELS": {
-            var _pd3 = Object.assign({}, profileData)
-            var blocks3 = val.split("|")
-            for (var bi3 = 0; bi3 < blocks3.length; bi3++) {
-                var blk3 = blocks3[bi3]
-                var c3 = blk3.indexOf(":")
-                if (c3 < 0) continue
-                var pname3 = blk3.substring(0, c3)
-                var mcsv = blk3.substring(c3 + 1)
-                if (!_pd3[pname3]) _pd3[pname3] = {}
-                var wms = []
-                if (mcsv.length > 0) {
-                    var mentries = mcsv.split(",")
-                    for (var mi = 0; mi < mentries.length; mi++) {
-                        var eq = mentries[mi].indexOf("=")
-                        if (eq < 0) continue
-                        wms.push({
-                            modelName:   mentries[mi].substring(0, eq),
-                            modelTokens: parseInt(mentries[mi].substring(eq + 1)) || 0
-                        })
-                    }
+                carr.push(k < cparts.length ? (parseFloat(cparts[k]) || 0) : 0);
+            dailyCosts = carr;
+            break;
+        case "PROFILES":
+            {
+                profileListModel.clear();
+                profileListModel.append({
+                    name: "all"
+                });
+                var profs = val.split(",");
+                for (var pi = 0; pi < profs.length; pi++)
+                    profileListModel.append({
+                        name: profs[pi]
+                    });
+                // Reset selectedProfile if it no longer exists in new profile list
+                if (selectedProfile !== "all") {
+                    var found = false;
+                    for (var fi = 0; fi < profs.length; fi++)
+                        if (profs[fi] === selectedProfile) {
+                            found = true;
+                            break;
+                        }
+                    if (!found)
+                        selectedProfile = "all";
                 }
-                _pd3[pname3].weekModels = wms
+                break;
             }
-            profileData = _pd3
-            break
-        }
+        case "PROFILE_WEEK_TOKENS":
+            profileData = parseProfileSimple(val, "weekTokens", false);
+            break;
+        case "PROFILE_MONTH_TOKENS":
+            profileData = parseProfileSimple(val, "monthTokens", false);
+            break;
+        case "PROFILE_TODAY_COST":
+            profileData = parseProfileSimple(val, "todayCost", true);
+            break;
+        case "PROFILE_WEEK_COST":
+            profileData = parseProfileSimple(val, "weekCost", true);
+            break;
+        case "PROFILE_MONTH_COST":
+            profileData = parseProfileSimple(val, "monthCost", true);
+            break;
+        case "PROFILE_SUBSCRIPTION":
+            profileData = parseProfileString(val, "subscriptionType");
+            break;
+        case "PROFILE_TIER":
+            profileData = parseProfileString(val, "rateLimitTier");
+            break;
+        case "PROFILE_FIVE_HOUR_UTIL":
+            profileData = parseProfileSimple(val, "fiveHourUtil", true);
+            break;
+        case "PROFILE_SEVEN_DAY_UTIL":
+            profileData = parseProfileSimple(val, "sevenDayUtil", true);
+            break;
+        case "PROFILE_FIVE_HOUR_RESET":
+            profileData = parseProfileString(val, "fiveHourReset");
+            break;
+        case "PROFILE_SEVEN_DAY_RESET":
+            profileData = parseProfileString(val, "sevenDayReset");
+            break;
+        case "PROFILE_EXTRA_USAGE":
+            profileData = parseProfileString(val, "extraUsageEnabled");
+            break;
+        case "PROFILE_DAILY":
+            {
+                var _pd1 = Object.assign({}, profileData);
+                var blocks1 = val.split("|");
+                for (var bi1 = 0; bi1 < blocks1.length; bi1++) {
+                    var blk1 = blocks1[bi1];
+                    var c1 = blk1.indexOf(":");
+                    if (c1 < 0)
+                        continue;
+                    var pname1 = blk1.substring(0, c1);
+                    var csv1 = blk1.substring(c1 + 1);
+                    if (!_pd1[pname1])
+                        _pd1[pname1] = {};
+                    var parts1 = csv1.split(",");
+                    var arr1 = [];
+                    for (var di = 0; di < 7; di++)
+                        arr1.push(di < parts1.length ? (parseFloat(parts1[di]) || 0) : 0);
+                    _pd1[pname1].daily = arr1;
+                }
+                profileData = _pd1;
+                break;
+            }
+        case "PROFILE_DAILY_COSTS":
+            {
+                var _pd2 = Object.assign({}, profileData);
+                var blocks2 = val.split("|");
+                for (var bi2 = 0; bi2 < blocks2.length; bi2++) {
+                    var blk2 = blocks2[bi2];
+                    var c2 = blk2.indexOf(":");
+                    if (c2 < 0)
+                        continue;
+                    var pname2 = blk2.substring(0, c2);
+                    var csv2 = blk2.substring(c2 + 1);
+                    if (!_pd2[pname2])
+                        _pd2[pname2] = {};
+                    var parts2 = csv2.split(",");
+                    var arr2 = [];
+                    for (var dci = 0; dci < 7; dci++)
+                        arr2.push(dci < parts2.length ? (parseFloat(parts2[dci]) || 0) : 0);
+                    _pd2[pname2].dailyCosts = arr2;
+                }
+                profileData = _pd2;
+                break;
+            }
+        case "PROFILE_WEEK_MODELS":
+            {
+                var _pd3 = Object.assign({}, profileData);
+                var blocks3 = val.split("|");
+                for (var bi3 = 0; bi3 < blocks3.length; bi3++) {
+                    var blk3 = blocks3[bi3];
+                    var c3 = blk3.indexOf(":");
+                    if (c3 < 0)
+                        continue;
+                    var pname3 = blk3.substring(0, c3);
+                    var mcsv = blk3.substring(c3 + 1);
+                    if (!_pd3[pname3])
+                        _pd3[pname3] = {};
+                    var wms = [];
+                    if (mcsv.length > 0) {
+                        var mentries = mcsv.split(",");
+                        for (var mi = 0; mi < mentries.length; mi++) {
+                            var eq = mentries[mi].indexOf("=");
+                            if (eq < 0)
+                                continue;
+                            wms.push({
+                                modelName: mentries[mi].substring(0, eq),
+                                modelTokens: parseInt(mentries[mi].substring(eq + 1)) || 0
+                            });
+                        }
+                    }
+                    _pd3[pname3].weekModels = wms;
+                }
+                profileData = _pd3;
+                break;
+            }
         }
     }
 
@@ -448,8 +555,8 @@ PluginComponent {
 
         onExited: (exitCode, exitStatus) => {
             if (exitCode === 0) {
-                root.isLoading = false
-                root.refreshEpoch++
+                root.isLoading = false;
+                root.refreshEpoch++;
             }
         }
     }
@@ -461,7 +568,7 @@ PluginComponent {
         triggeredOnStart: true
         onTriggered: {
             if (!usageProcess.running)
-                usageProcess.running = true
+                usageProcess.running = true;
         }
     }
 
@@ -482,24 +589,24 @@ PluginComponent {
                 onPercentChanged: requestPaint()
 
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5;
 
-                    ctx.beginPath()
-                    ctx.arc(cx, cy, r, 0, 2 * Math.PI)
-                    ctx.lineWidth = lw
-                    ctx.strokeStyle = Theme.surfaceVariant
-                    ctx.stroke()
+                    ctx.beginPath();
+                    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                    ctx.lineWidth = lw;
+                    ctx.strokeStyle = Theme.surfaceVariant;
+                    ctx.stroke();
 
-                    var pct = percent / 100
+                    var pct = percent / 100;
                     if (pct > 0) {
-                        ctx.beginPath()
-                        ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1))
-                        ctx.lineWidth = lw
-                        ctx.strokeStyle = root.progressColor(percent)
-                        ctx.lineCap = "round"
-                        ctx.stroke()
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                        ctx.lineWidth = lw;
+                        ctx.strokeStyle = root.progressColor(percent);
+                        ctx.lineCap = "round";
+                        ctx.stroke();
                     }
                 }
             }
@@ -528,24 +635,24 @@ PluginComponent {
                 onPercentChanged: requestPaint()
 
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5;
 
-                    ctx.beginPath()
-                    ctx.arc(cx, cy, r, 0, 2 * Math.PI)
-                    ctx.lineWidth = lw
-                    ctx.strokeStyle = Theme.surfaceVariant
-                    ctx.stroke()
+                    ctx.beginPath();
+                    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                    ctx.lineWidth = lw;
+                    ctx.strokeStyle = Theme.surfaceVariant;
+                    ctx.stroke();
 
-                    var pct = percent / 100
+                    var pct = percent / 100;
                     if (pct > 0) {
-                        ctx.beginPath()
-                        ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1))
-                        ctx.lineWidth = lw
-                        ctx.strokeStyle = root.progressColor(percent)
-                        ctx.lineCap = "round"
-                        ctx.stroke()
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                        ctx.lineWidth = lw;
+                        ctx.strokeStyle = root.progressColor(percent);
+                        ctx.lineCap = "round";
+                        ctx.stroke();
                     }
                 }
             }
@@ -573,12 +680,12 @@ PluginComponent {
                     width: tabLabel.implicitWidth + Theme.spacingM * 2
                     height: 32
                     radius: 16
-                    color: root.selectedProfile === name
-                        ? Theme.primary
-                        : Theme.surfaceVariant
+                    color: root.selectedProfile === name ? Theme.primary : Theme.surfaceVariant
 
                     Behavior on color {
-                        ColorAnimation { duration: 120 }
+                        ColorAnimation {
+                            duration: 120
+                        }
                     }
 
                     StyledText {
@@ -587,9 +694,7 @@ PluginComponent {
                         text: name === "all" ? root.tr("All") : name
                         font.pixelSize: Theme.fontSizeSmall
                         font.weight: root.selectedProfile === name ? Font.Medium : Font.Normal
-                        color: root.selectedProfile === name
-                            ? Theme.primaryText
-                            : Theme.surfaceVariantText
+                        color: root.selectedProfile === name ? Theme.primaryText : Theme.surfaceVariantText
                     }
 
                     MouseArea {
@@ -627,9 +732,7 @@ PluginComponent {
 
                 StyledText {
                     anchors.verticalCenter: parent.verticalCenter
-                    text: root.selectedProfile === "all"
-                        ? root.tr("All")
-                        : root.selectedProfile
+                    text: root.selectedProfile === "all" ? root.tr("All") : root.selectedProfile
                     font.pixelSize: Theme.fontSizeSmall
                     font.weight: Font.Medium
                     color: Theme.surfaceText
@@ -666,9 +769,7 @@ PluginComponent {
                             width: parent.width
                             height: 28
                             radius: 4
-                            color: root.selectedProfile === name
-                                ? Theme.primary
-                                : "transparent"
+                            color: root.selectedProfile === name ? Theme.primary : "transparent"
 
                             StyledText {
                                 anchors.verticalCenter: parent.verticalCenter
@@ -676,17 +777,15 @@ PluginComponent {
                                 anchors.leftMargin: Theme.spacingXS
                                 text: name === "all" ? root.tr("All") : name
                                 font.pixelSize: Theme.fontSizeSmall
-                                color: root.selectedProfile === name
-                                    ? Theme.primaryText
-                                    : Theme.surfaceText
+                                color: root.selectedProfile === name ? Theme.primaryText : Theme.surfaceText
                             }
 
                             MouseArea {
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: {
-                                    root.selectedProfile = name
-                                    profileDropdownPopup.visible = false
+                                    root.selectedProfile = name;
+                                    profileDropdownPopup.visible = false;
                                 }
                             }
                         }
@@ -700,8 +799,8 @@ PluginComponent {
         PopoutComponent {
             headerText: root.tr("Claude Code Usage")
             detailsText: {
-                var label = root.formatSubscription(root.displaySubscriptionType, root.displayRateLimitTier)
-                return label ? root.tr("Subscription") + ": " + label : ""
+                var label = root.formatSubscription(root.displaySubscriptionType, root.displayRateLimitTier);
+                return label ? root.tr("Subscription") + ": " + label : "";
             }
             showCloseButton: true
 
@@ -723,9 +822,7 @@ PluginComponent {
                         width: parent.width
                         // Explicit height binding — Loader defaults to 0 without this
                         height: item ? item.implicitHeight : 0
-                        sourceComponent: profileListModel.count <= 5
-                            ? profileTabsComponent
-                            : profileDropdownComponent
+                        sourceComponent: profileListModel.count <= 5 ? profileTabsComponent : profileDropdownComponent
                     }
                 }
 
@@ -752,24 +849,24 @@ PluginComponent {
                             onPercentChanged: requestPaint()
 
                             onPaint: {
-                                var ctx = getContext("2d")
-                                ctx.reset()
-                                var cx = width / 2, cy = height / 2, r = 38, lw = 8
+                                var ctx = getContext("2d");
+                                ctx.reset();
+                                var cx = width / 2, cy = height / 2, r = 38, lw = 8;
 
-                                ctx.beginPath()
-                                ctx.arc(cx, cy, r, 0, 2 * Math.PI)
-                                ctx.lineWidth = lw
-                                ctx.strokeStyle = Theme.surfaceVariant
-                                ctx.stroke()
+                                ctx.beginPath();
+                                ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                                ctx.lineWidth = lw;
+                                ctx.strokeStyle = Theme.surfaceVariant;
+                                ctx.stroke();
 
-                                var pct = percent / 100
+                                var pct = percent / 100;
                                 if (pct > 0) {
-                                    ctx.beginPath()
-                                    ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1))
-                                    ctx.lineWidth = lw
-                                    ctx.strokeStyle = root.progressColor(percent)
-                                    ctx.lineCap = "round"
-                                    ctx.stroke()
+                                    ctx.beginPath();
+                                    ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                                    ctx.lineWidth = lw;
+                                    ctx.strokeStyle = root.progressColor(percent);
+                                    ctx.lineCap = "round";
+                                    ctx.stroke();
                                 }
                             }
 
@@ -830,24 +927,24 @@ PluginComponent {
                             onPercentChanged: requestPaint()
 
                             onPaint: {
-                                var ctx = getContext("2d")
-                                ctx.reset()
-                                var cx = width / 2, cy = height / 2, r = 28, lw = 6
+                                var ctx = getContext("2d");
+                                ctx.reset();
+                                var cx = width / 2, cy = height / 2, r = 28, lw = 6;
 
-                                ctx.beginPath()
-                                ctx.arc(cx, cy, r, 0, 2 * Math.PI)
-                                ctx.lineWidth = lw
-                                ctx.strokeStyle = Theme.surfaceVariant
-                                ctx.stroke()
+                                ctx.beginPath();
+                                ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                                ctx.lineWidth = lw;
+                                ctx.strokeStyle = Theme.surfaceVariant;
+                                ctx.stroke();
 
-                                var pct = percent / 100
+                                var pct = percent / 100;
                                 if (pct > 0) {
-                                    ctx.beginPath()
-                                    ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1))
-                                    ctx.lineWidth = lw
-                                    ctx.strokeStyle = root.progressColor(percent)
-                                    ctx.lineCap = "round"
-                                    ctx.stroke()
+                                    ctx.beginPath();
+                                    ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                                    ctx.lineWidth = lw;
+                                    ctx.strokeStyle = root.progressColor(percent);
+                                    ctx.lineCap = "round";
+                                    ctx.stroke();
                                 }
                             }
 
@@ -872,10 +969,12 @@ PluginComponent {
                             }
                             StyledText {
                                 text: {
-                                    var parts = []
-                                    if (root.weekSessions > 0) parts.push(root.weekSessions + " " + root.tr("sessions"))
-                                    if (root.weekMessages > 0) parts.push(root.weekMessages + " " + root.tr("msgs"))
-                                    return parts.join(" · ")
+                                    var parts = [];
+                                    if (root.weekSessions > 0)
+                                        parts.push(root.weekSessions + " " + root.tr("sessions"));
+                                    if (root.weekMessages > 0)
+                                        parts.push(root.weekMessages + " " + root.tr("msgs"));
+                                    return parts.join(" · ");
                                 }
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: Theme.surfaceVariantText
@@ -1039,17 +1138,15 @@ PluginComponent {
                                                 anchors.bottom: parent.bottom
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 width: Math.max(parent.width - 4, 4)
-                                                height: root.maxDaily > 0
-                                                    ? Math.max(root.dailyTokens[index] / root.maxDaily * parent.height, root.dailyTokens[index] > 0 ? 3 : 0)
-                                                    : 0
+                                                height: root.maxDaily > 0 ? Math.max(root.dailyTokens[index] / root.maxDaily * parent.height, root.dailyTokens[index] > 0 ? 3 : 0) : 0
                                                 radius: 2
-                                                color: root.selectedProfile === "all"
-                                                    ? (index === root.todayIndex ? Theme.primary : Theme.surfaceVariant)
-                                                    : Theme.surfaceVariant
+                                                color: root.selectedProfile === "all" ? (index === root.todayIndex ? Theme.primary : Theme.surfaceVariant) : Theme.surfaceVariant
                                                 opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
 
                                                 Behavior on opacity {
-                                                    NumberAnimation { duration: 120 }
+                                                    NumberAnimation {
+                                                        duration: 120
+                                                    }
                                                 }
                                             }
 
@@ -1059,15 +1156,15 @@ PluginComponent {
                                                 anchors.bottom: parent.bottom
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 width: Math.max(parent.width - 4, 4)
-                                                height: root.maxDaily > 0 && root.profileDailyTokens.length > index
-                                                    ? Math.max(root.profileDailyTokens[index] / root.maxDaily * parent.height, root.profileDailyTokens[index] > 0 ? 3 : 0)
-                                                    : 0
+                                                height: root.maxDaily > 0 && root.profileDailyTokens.length > index ? Math.max(root.profileDailyTokens[index] / root.maxDaily * parent.height, root.profileDailyTokens[index] > 0 ? 3 : 0) : 0
                                                 radius: 2
                                                 color: Theme.primary
                                                 opacity: root.hoveredDay >= 0 && index !== root.hoveredDay ? 0.4 : 1.0
 
                                                 Behavior on opacity {
-                                                    NumberAnimation { duration: 120 }
+                                                    NumberAnimation {
+                                                        duration: 120
+                                                    }
                                                 }
                                             }
 
@@ -1084,9 +1181,7 @@ PluginComponent {
                                             id: dayLabel
                                             text: root.dayLabels[index]
                                             font.pixelSize: 11
-                                            color: index === root.hoveredDay
-                                                ? Theme.primary
-                                                : index === root.todayIndex ? Theme.primary : Theme.surfaceVariantText
+                                            color: index === root.hoveredDay ? Theme.primary : index === root.todayIndex ? Theme.primary : Theme.surfaceVariantText
                                             anchors.horizontalCenter: parent.horizontalCenter
                                         }
                                     }
@@ -1102,15 +1197,15 @@ PluginComponent {
                         z: 10
 
                         x: {
-                            var colW = (chartRow.width - 6 * 4) / 7
-                            var cx = root.hoveredDay * (colW + 4) + colW / 2 - width / 2
-                            var chartX = chartRow.mapToItem(chartTooltip.parent, 0, 0).x
-                            var raw = chartX + cx
-                            return Math.max(Theme.spacingM, Math.min(raw, parent.width - width - Theme.spacingM))
+                            var colW = (chartRow.width - 6 * 4) / 7;
+                            var cx = root.hoveredDay * (colW + 4) + colW / 2 - width / 2;
+                            var chartX = chartRow.mapToItem(chartTooltip.parent, 0, 0).x;
+                            var raw = chartX + cx;
+                            return Math.max(Theme.spacingM, Math.min(raw, parent.width - width - Theme.spacingM));
                         }
                         y: {
-                            var chartY = chartRow.mapToItem(chartTooltip.parent, 0, 0).y
-                            return chartY - height - 2
+                            var chartY = chartRow.mapToItem(chartTooltip.parent, 0, 0).y;
+                            return chartY - height - 2;
                         }
 
                         width: tooltipCol.width + Theme.spacingS * 2
@@ -1126,9 +1221,10 @@ PluginComponent {
                             // Line 1: total tokens (with "total" suffix when a profile is selected)
                             StyledText {
                                 text: {
-                                    if (root.hoveredDay < 0) return ""
-                                    var t = root.formatTokens(root.dailyTokens[root.hoveredDay])
-                                    return root.selectedProfile !== "all" ? t + " total" : t
+                                    if (root.hoveredDay < 0)
+                                        return "";
+                                    var t = root.formatTokens(root.dailyTokens[root.hoveredDay]);
+                                    return root.selectedProfile !== "all" ? t + " total" : t;
                                 }
                                 font.pixelSize: 11
                                 font.weight: Font.DemiBold
@@ -1138,13 +1234,11 @@ PluginComponent {
 
                             // Line 2: profile tokens (only when a profile is selected and has data)
                             StyledText {
-                                visible: root.selectedProfile !== "all"
-                                    && root.hoveredDay >= 0
-                                    && root.profileDailyTokens.length > root.hoveredDay
-                                    && root.profileDailyTokens[root.hoveredDay] > 0
+                                visible: root.selectedProfile !== "all" && root.hoveredDay >= 0 && root.profileDailyTokens.length > root.hoveredDay && root.profileDailyTokens[root.hoveredDay] > 0
                                 text: {
-                                    if (root.hoveredDay < 0 || root.profileDailyTokens.length <= root.hoveredDay) return ""
-                                    return root.formatTokens(root.profileDailyTokens[root.hoveredDay]) + " " + root.selectedProfile
+                                    if (root.hoveredDay < 0 || root.profileDailyTokens.length <= root.hoveredDay)
+                                        return "";
+                                    return root.formatTokens(root.profileDailyTokens[root.hoveredDay]) + " " + root.selectedProfile;
                                 }
                                 font.pixelSize: 11
                                 color: Theme.primary
@@ -1169,9 +1263,10 @@ PluginComponent {
                     height: modelCardCol.implicitHeight + Theme.spacingM * 2
                     color: Theme.surfaceContainerHigh
                     visible: {
-                        if (root.selectedProfile === "all") return modelListData.count > 0
-                        var pd = root.profileData[root.selectedProfile]
-                        return pd && pd.weekModels && pd.weekModels.length > 0
+                        if (root.selectedProfile === "all")
+                            return modelListData.count > 0;
+                        var pd = root.profileData[root.selectedProfile];
+                        return pd && pd.weekModels && pd.weekModels.length > 0;
                     }
 
                     Column {
@@ -1195,9 +1290,10 @@ PluginComponent {
                             Repeater {
                                 id: modelRepeater
                                 model: {
-                                    if (root.selectedProfile === "all") return modelListData
-                                    var pd = root.profileData[root.selectedProfile]
-                                    return (pd && pd.weekModels) ? pd.weekModels : []
+                                    if (root.selectedProfile === "all")
+                                        return modelListData;
+                                    var pd = root.profileData[root.selectedProfile];
+                                    return (pd && pd.weekModels) ? pd.weekModels : [];
                                 }
                                 delegate: Column {
                                     width: modelCol.width
@@ -1205,12 +1301,8 @@ PluginComponent {
 
                                     // When model is a ListModel, role names are direct properties.
                                     // When model is a JS array, values are accessed via modelData.
-                                    property string _modelName: modelListData === modelRepeater.model
-                                        ? modelName
-                                        : (modelData ? modelData.modelName : "")
-                                    property int _modelTokens: modelListData === modelRepeater.model
-                                        ? modelTokens
-                                        : (modelData ? (modelData.modelTokens || 0) : 0)
+                                    property string _modelName: modelListData === modelRepeater.model ? modelName : (modelData ? modelData.modelName : "")
+                                    property int _modelTokens: modelListData === modelRepeater.model ? modelTokens : (modelData ? (modelData.modelTokens || 0) : 0)
 
                                     Row {
                                         width: parent.width
@@ -1235,9 +1327,7 @@ PluginComponent {
                                         color: Theme.surfaceVariant
 
                                         Rectangle {
-                                            width: root.displayWeekTokens > 0
-                                                ? parent.width * Math.min(_modelTokens / root.displayWeekTokens, 1)
-                                                : 0
+                                            width: root.displayWeekTokens > 0 ? parent.width * Math.min(_modelTokens / root.displayWeekTokens, 1) : 0
                                             height: parent.height
                                             radius: 2
                                             color: Theme.primary
@@ -1271,12 +1361,12 @@ PluginComponent {
 
                         StyledText {
                             text: {
-                                var parts = []
+                                var parts = [];
                                 if (root.firstSession && root.firstSession !== "unknown")
-                                    parts.push(root.tr("Since") + " " + root.firstSession)
-                                parts.push(root.alltimeSessions + " " + root.tr("sessions"))
-                                parts.push(root.alltimeMessages.toLocaleString() + " " + root.tr("msgs"))
-                                return parts.join("  ·  ")
+                                    parts.push(root.tr("Since") + " " + root.firstSession);
+                                parts.push(root.alltimeSessions + " " + root.tr("sessions"));
+                                parts.push(root.alltimeMessages.toLocaleString() + " " + root.tr("msgs"));
+                                return parts.join("  ·  ");
                             }
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceVariantText
@@ -1287,7 +1377,10 @@ PluginComponent {
                 }
 
                 // Bottom padding to match sides (compensates Column spacing)
-                Item { width: 1; height: 1 }
+                Item {
+                    width: 1
+                    height: 1
+                }
             }
         }
     }

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -119,7 +119,7 @@ PluginComponent {
     property string scriptPath: PluginService.pluginDirectory + "/claudeCodeUsage/get-claude-usage"
 
     popoutWidth: 380
-    popoutHeight: 660
+    popoutHeight: 740
 
     // --- Helpers ---
 
@@ -479,6 +479,141 @@ PluginComponent {
 
     // --- Popout ---
 
+    // Profile selector components — declared at root scope for Loader access
+    Component {
+        id: profileTabsComponent
+        Row {
+            spacing: Theme.spacingXS
+
+            Repeater {
+                model: profileListModel
+                delegate: Rectangle {
+                    width: tabLabel.implicitWidth + Theme.spacingM * 2
+                    height: 32
+                    radius: 16
+                    color: root.selectedProfile === name
+                        ? Theme.primary
+                        : Theme.surfaceVariant
+
+                    Behavior on color {
+                        ColorAnimation { duration: 120 }
+                    }
+
+                    StyledText {
+                        id: tabLabel
+                        anchors.centerIn: parent
+                        text: name === "all" ? root.tr("All") : name
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: root.selectedProfile === name ? Font.Medium : Font.Normal
+                        color: root.selectedProfile === name
+                            ? Theme.primaryText
+                            : Theme.surfaceVariantText
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.selectedProfile = name
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: profileDropdownComponent
+        Rectangle {
+            // Note: z:100 on popup is scoped to subtree; cards below may overlap when open.
+            // Acceptable for >5 profiles (rare case). Full modal overlay is out of scope.
+            width: parent ? parent.width : 0
+            height: 36
+            radius: 8
+            color: Theme.surfaceVariant
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingM
+                anchors.rightMargin: Theme.spacingM
+                spacing: Theme.spacingXS
+
+                StyledText {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: root.tr("Profile") + ":"
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                }
+
+                StyledText {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: root.selectedProfile === "all"
+                        ? root.tr("All")
+                        : root.selectedProfile
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: profileDropdownPopup.visible = !profileDropdownPopup.visible
+            }
+
+            Rectangle {
+                id: profileDropdownPopup
+                visible: false
+                z: 100
+                anchors.top: parent.bottom
+                anchors.topMargin: 4
+                anchors.left: parent.left
+                width: parent.width
+                height: dropdownCol.implicitHeight + Theme.spacingS * 2
+                radius: 8
+                color: Theme.surfaceContainer
+
+                Column {
+                    id: dropdownCol
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingS
+                    spacing: 2
+
+                    Repeater {
+                        model: profileListModel
+                        delegate: Rectangle {
+                            width: parent.width
+                            height: 28
+                            radius: 4
+                            color: root.selectedProfile === name
+                                ? Theme.primary
+                                : "transparent"
+
+                            StyledText {
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.left: parent.left
+                                anchors.leftMargin: Theme.spacingXS
+                                text: name === "all" ? root.tr("All") : name
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: root.selectedProfile === name
+                                    ? Theme.primaryText
+                                    : Theme.surfaceText
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    root.selectedProfile = name
+                                    profileDropdownPopup.visible = false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     popoutContent: Component {
         PopoutComponent {
             headerText: root.tr("Claude Code Usage")
@@ -489,6 +624,24 @@ PluginComponent {
                 width: parent.width - Theme.spacingM * 2
                 anchors.horizontalCenter: parent.horizontalCenter
                 spacing: Theme.spacingL
+
+                // --- Profile selector (tabs ≤5 entries, dropdown >5) ---
+                // Hidden when only default profile (no CCS instances)
+                Item {
+                    width: parent.width
+                    height: profileSelectorLoader.height
+                    visible: profileListModel.count > 1
+
+                    Loader {
+                        id: profileSelectorLoader
+                        width: parent.width
+                        // Explicit height binding — Loader defaults to 0 without this
+                        height: item ? item.implicitHeight : 0
+                        sourceComponent: profileListModel.count <= 5
+                            ? profileTabsComponent
+                            : profileDropdownComponent
+                    }
+                }
 
                 // --- 5h Rate Window card ---
                 StyledRect {

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -229,11 +229,27 @@ PluginComponent {
     }
 
     function formatTier(tier) {
+        if (!tier || tier === "unknown") return ""
         if (tier.indexOf("max_20x") >= 0) return "Max 20x"
         if (tier.indexOf("max_5x") >= 0) return "Max 5x"
+        if (tier.indexOf("max") >= 0) return "Max"
         if (tier.indexOf("pro") >= 0) return "Pro"
         if (tier.indexOf("free") >= 0) return "Free"
-        return tier
+        if (tier.indexOf("team") >= 0) return "Team"
+        if (tier.indexOf("enterprise") >= 0) return "Enterprise"
+        return tier.replace(/_/g, " ").replace(/\b\w/g, function(c) { return c.toUpperCase() })
+    }
+
+    function formatSubscription(subType, tier) {
+        var tierLabel = formatTier(tier)
+        if (!subType || subType === "unknown") return tierLabel
+        // Normalize subscriptionType like "claude_pro" → "Pro", "claude_max" → "Max"
+        var subLabel = subType.replace(/^claude[_-]?/i, "")
+                              .replace(/_/g, " ")
+                              .replace(/\b\w/g, function(c) { return c.toUpperCase() })
+        // Prefer tier label if it adds info beyond subType
+        if (tierLabel && tierLabel !== subLabel) return subLabel + " · " + tierLabel
+        return subLabel || tierLabel
     }
 
     // Helper: parse "name:value,name:value,..." into profileData[name][field]
@@ -693,7 +709,10 @@ PluginComponent {
     popoutContent: Component {
         PopoutComponent {
             headerText: root.tr("Claude Code Usage")
-            detailsText: root.rateLimitTier ? root.tr("Subscription") + ": " + root.formatTier(root.rateLimitTier) : ""
+            detailsText: {
+                var label = root.formatSubscription(root.subscriptionType, root.rateLimitTier)
+                return label ? root.tr("Subscription") + ": " + label : ""
+            }
             showCloseButton: true
 
             Column {
@@ -1184,6 +1203,7 @@ PluginComponent {
                             spacing: Theme.spacingS
 
                             Repeater {
+                                id: modelRepeater
                                 model: {
                                     if (root.selectedProfile === "all") return modelListData
                                     var pd = root.profileData[root.selectedProfile]
@@ -1193,17 +1213,26 @@ PluginComponent {
                                     width: modelCol.width
                                     spacing: 3
 
+                                    // When model is a ListModel, role names are direct properties.
+                                    // When model is a JS array, values are accessed via modelData.
+                                    property string _modelName: modelListData === modelRepeater.model
+                                        ? modelName
+                                        : (modelData ? modelData.modelName : "")
+                                    property int _modelTokens: modelListData === modelRepeater.model
+                                        ? modelTokens
+                                        : (modelData ? (modelData.modelTokens || 0) : 0)
+
                                     Row {
                                         width: parent.width
                                         spacing: Theme.spacingXS
 
                                         StyledText {
-                                            text: root.shortModelName(modelName)
+                                            text: root.shortModelName(_modelName)
                                             font.pixelSize: Theme.fontSizeSmall
                                             color: Theme.surfaceText
                                         }
                                         StyledText {
-                                            text: root.formatTokens(modelTokens)
+                                            text: root.formatTokens(_modelTokens)
                                             font.pixelSize: Theme.fontSizeSmall
                                             color: Theme.surfaceVariantText
                                         }
@@ -1217,7 +1246,7 @@ PluginComponent {
 
                                         Rectangle {
                                             width: root.displayWeekTokens > 0
-                                                ? parent.width * Math.min(modelTokens / root.displayWeekTokens, 1)
+                                                ? parent.width * Math.min(_modelTokens / root.displayWeekTokens, 1)
                                                 : 0
                                             height: parent.height
                                             radius: 2
@@ -1235,7 +1264,7 @@ PluginComponent {
                     width: parent.width
                     height: allTimeRow.implicitHeight + Theme.spacingM * 2
                     color: Theme.surfaceContainerHigh
-                    visible: root.alltimeSessions > 0 || root.alltimeMessages > 0
+                    visible: root.selectedProfile === "all" && (root.alltimeSessions > 0 || root.alltimeMessages > 0)
 
                     Row {
                         id: allTimeRow

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -71,6 +71,75 @@ PluginComponent {
     ListModel { id: profileListModel }
     // First entry is always { name: "all" }; populated by PROFILES output field.
 
+    // Computed display values — switch between aggregate and per-profile data.
+    // When selectedProfile === "all" or profile has no data, fall back to aggregates.
+    property real displayFiveHourUtil: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return fiveHourUtil
+        return profileData[selectedProfile].fiveHourUtil || 0
+    }
+    property string displayFiveHourReset: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return fiveHourReset
+        return profileData[selectedProfile].fiveHourReset || ""
+    }
+    property real displaySevenDayUtil: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return sevenDayUtil
+        return profileData[selectedProfile].sevenDayUtil || 0
+    }
+    property string displaySevenDayReset: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return sevenDayReset
+        return profileData[selectedProfile].sevenDayReset || ""
+    }
+    property real displayWeekTokens: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return weekTokens
+        return profileData[selectedProfile].weekTokens || 0
+    }
+    property real displayMonthTokens: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return monthTokens
+        return profileData[selectedProfile].monthTokens || 0
+    }
+    property real displayTodayCost: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return todayCost
+        return profileData[selectedProfile].todayCost || 0
+    }
+    property real displayWeekCost: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return weekCost
+        return profileData[selectedProfile].weekCost || 0
+    }
+    property real displayMonthCost: {
+        if (selectedProfile === "all" || !profileData[selectedProfile]) return monthCost
+        return profileData[selectedProfile].monthCost || 0
+    }
+    property var displayDailyTokens: {
+        if (selectedProfile === "all" || !profileData[selectedProfile] || !profileData[selectedProfile].daily)
+            return dailyTokens
+        return profileData[selectedProfile].daily
+    }
+    // Note: displayDailyCosts is intentionally NOT defined.
+    // The tooltip cost line always shows aggregate dailyCosts per spec.
+    // The Token Consumption card uses displayTodayCost/displayWeekCost/displayMonthCost instead.
+
+    property string displayFiveHourCountdown: {
+        if (!displayFiveHourReset) return ""
+        var resetMs = new Date(displayFiveHourReset).getTime()
+        var remaining = Math.max(0, resetMs - countdownNow)
+        if (remaining <= 0) return tr("Resetting...")
+        var hours = Math.floor(remaining / 3600000)
+        var mins = Math.floor((remaining % 3600000) / 60000)
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+    }
+
+    property string displaySevenDayCountdown: {
+        if (!displaySevenDayReset) return ""
+        var resetMs = new Date(displaySevenDayReset).getTime()
+        var remaining = Math.max(0, resetMs - countdownNow)
+        if (remaining <= 0) return tr("Resetting...")
+        var days = Math.floor(remaining / 86400000)
+        var hours = Math.floor((remaining % 86400000) / 3600000)
+        var mins = Math.floor((remaining % 3600000) / 60000)
+        if (days > 0) return days + "d " + hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+        return hours + "h " + (mins < 10 ? "0" : "") + mins + "m"
+    }
+
     // Today's index in the calendar week (0=Monday, 6=Sunday)
     property int todayIndex: {
         void(refreshEpoch)
@@ -662,7 +731,7 @@ PluginComponent {
                             anchors.verticalCenter: parent.verticalCenter
                             renderStrategy: Canvas.Cooperative
 
-                            property real percent: root.fiveHourUtil
+                            property real percent: root.displayFiveHourUtil
                             onPercentChanged: requestPaint()
 
                             onPaint: {
@@ -689,7 +758,7 @@ PluginComponent {
 
                             StyledText {
                                 anchors.centerIn: parent
-                                text: Math.round(root.fiveHourUtil) + "%"
+                                text: Math.round(root.displayFiveHourUtil) + "%"
                                 font.pixelSize: Theme.fontSizeXLarge
                                 font.weight: Font.DemiBold
                                 color: Theme.surfaceText
@@ -707,15 +776,15 @@ PluginComponent {
                                 color: Theme.surfaceText
                             }
                             StyledText {
-                                text: Math.round(root.fiveHourUtil) + "% " + root.tr("used")
+                                text: Math.round(root.displayFiveHourUtil) + "% " + root.tr("used")
                                 font.pixelSize: Theme.fontSizeMedium
-                                color: root.progressColor(root.fiveHourUtil)
+                                color: root.progressColor(root.displayFiveHourUtil)
                             }
                             StyledText {
-                                text: root.fiveHourCountdown ? root.tr("Resets in") + " " + root.fiveHourCountdown : ""
+                                text: root.displayFiveHourCountdown ? root.tr("Resets in") + " " + root.displayFiveHourCountdown : ""
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.surfaceVariantText
-                                visible: root.fiveHourCountdown !== ""
+                                visible: root.displayFiveHourCountdown !== ""
                             }
                         }
                     }
@@ -740,7 +809,7 @@ PluginComponent {
                             anchors.verticalCenter: parent.verticalCenter
                             renderStrategy: Canvas.Cooperative
 
-                            property real percent: root.sevenDayUtil
+                            property real percent: root.displaySevenDayUtil
                             onPercentChanged: requestPaint()
 
                             onPaint: {
@@ -767,7 +836,7 @@ PluginComponent {
 
                             StyledText {
                                 anchors.centerIn: parent
-                                text: Math.round(root.sevenDayUtil) + "%"
+                                text: Math.round(root.displaySevenDayUtil) + "%"
                                 font.pixelSize: 14
                                 font.weight: Font.DemiBold
                                 color: Theme.surfaceText
@@ -779,7 +848,7 @@ PluginComponent {
                             spacing: Theme.spacingXS
 
                             StyledText {
-                                text: root.tr("7-Day Usage") + " · " + Math.round(root.sevenDayUtil) + "%"
+                                text: root.tr("7-Day Usage") + " · " + Math.round(root.displaySevenDayUtil) + "%"
                                 font.pixelSize: Theme.fontSizeMedium
                                 font.weight: Font.Medium
                                 color: Theme.surfaceText
@@ -793,12 +862,13 @@ PluginComponent {
                                 }
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: Theme.surfaceVariantText
+                                visible: root.selectedProfile === "all"
                             }
                             StyledText {
-                                text: root.sevenDayCountdown ? root.tr("Resets in") + " " + root.sevenDayCountdown : ""
+                                text: root.displaySevenDayCountdown ? root.tr("Resets in") + " " + root.displaySevenDayCountdown : ""
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: Theme.surfaceVariantText
-                                visible: root.sevenDayCountdown !== ""
+                                visible: root.displaySevenDayCountdown !== ""
                             }
                         }
                     }
@@ -837,18 +907,18 @@ PluginComponent {
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatTokens(root.dailyTokens[root.todayIndex])
+                                    text: root.formatTokens(root.displayDailyTokens[root.todayIndex])
                                     font.pixelSize: Theme.fontSizeLarge
                                     font.weight: Font.DemiBold
                                     color: Theme.primary
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatCost(root.todayCost)
+                                    text: root.formatCost(root.displayTodayCost)
                                     font.pixelSize: Theme.fontSizeSmall
                                     color: Theme.surfaceVariantText
                                     anchors.horizontalCenter: parent.horizontalCenter
-                                    visible: root.todayCost > 0
+                                    visible: root.displayTodayCost > 0
                                 }
                             }
 
@@ -863,18 +933,18 @@ PluginComponent {
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatTokens(root.weekTokens)
+                                    text: root.formatTokens(root.displayWeekTokens)
                                     font.pixelSize: Theme.fontSizeLarge
                                     font.weight: Font.DemiBold
                                     color: Theme.surfaceText
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatCost(root.weekCost)
+                                    text: root.formatCost(root.displayWeekCost)
                                     font.pixelSize: Theme.fontSizeSmall
                                     color: Theme.surfaceVariantText
                                     anchors.horizontalCenter: parent.horizontalCenter
-                                    visible: root.weekCost > 0
+                                    visible: root.displayWeekCost > 0
                                 }
                             }
 
@@ -889,18 +959,18 @@ PluginComponent {
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatTokens(root.monthTokens)
+                                    text: root.formatTokens(root.displayMonthTokens)
                                     font.pixelSize: Theme.fontSizeLarge
                                     font.weight: Font.DemiBold
                                     color: Theme.surfaceText
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatCost(root.monthCost)
+                                    text: root.formatCost(root.displayMonthCost)
                                     font.pixelSize: Theme.fontSizeSmall
                                     color: Theme.surfaceVariantText
                                     anchors.horizontalCenter: parent.horizontalCenter
-                                    visible: root.monthCost > 0
+                                    visible: root.displayMonthCost > 0
                                 }
                             }
                         }
@@ -1040,7 +1110,11 @@ PluginComponent {
                     width: parent.width
                     height: modelCardCol.implicitHeight + Theme.spacingM * 2
                     color: Theme.surfaceContainerHigh
-                    visible: modelListData.count > 0
+                    visible: {
+                        if (root.selectedProfile === "all") return modelListData.count > 0
+                        var pd = root.profileData[root.selectedProfile]
+                        return pd && pd.weekModels && pd.weekModels.length > 0
+                    }
 
                     Column {
                         id: modelCardCol
@@ -1061,7 +1135,11 @@ PluginComponent {
                             spacing: Theme.spacingS
 
                             Repeater {
-                                model: modelListData
+                                model: {
+                                    if (root.selectedProfile === "all") return modelListData
+                                    var pd = root.profileData[root.selectedProfile]
+                                    return (pd && pd.weekModels) ? pd.weekModels : []
+                                }
                                 delegate: Column {
                                     width: modelCol.width
                                     spacing: 3
@@ -1089,8 +1167,8 @@ PluginComponent {
                                         color: Theme.surfaceVariant
 
                                         Rectangle {
-                                            width: root.weekTokens > 0
-                                                ? parent.width * Math.min(modelTokens / root.weekTokens, 1)
+                                            width: root.displayWeekTokens > 0
+                                                ? parent.width * Math.min(modelTokens / root.displayWeekTokens, 1)
                                                 : 0
                                             height: parent.height
                                             radius: 2

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -702,11 +702,12 @@ PluginComponent {
                 spacing: Theme.spacingL
 
                 // --- Profile selector (tabs ≤5 entries, dropdown >5) ---
-                // Hidden when only default profile (no CCS instances)
+                // Hidden when only one real profile (e.g. default only, no CCS instances)
+                // count > 2 means "All" + at least 2 real profiles
                 Item {
                     width: parent.width
                     height: profileSelectorLoader.height
-                    visible: profileListModel.count > 1
+                    visible: profileListModel.count > 2
 
                     Loader {
                         id: profileSelectorLoader

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -287,6 +287,8 @@ PluginComponent {
             var v = isFloat ? (parseFloat(entry.substring(colon + 1)) || 0) : (parseInt(entry.substring(colon + 1)) || 0);
             if (!_pd[name])
                 _pd[name] = {};
+            else
+                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = v;
         }
         return _pd;
@@ -306,6 +308,8 @@ PluginComponent {
             var name = entry.substring(0, colon);
             if (!_pd[name])
                 _pd[name] = {};
+            else
+                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = entry.substring(colon + 1);
         }
         return _pd;
@@ -322,6 +326,8 @@ PluginComponent {
             var name = entry.substring(0, colon);
             if (!_pd[name])
                 _pd[name] = {};
+            else
+                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = entry.substring(colon + 1) === "true";
         }
         return _pd;

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -287,6 +287,8 @@ PluginComponent {
             var v = isFloat ? (parseFloat(entry.substring(colon + 1)) || 0) : (parseInt(entry.substring(colon + 1)) || 0);
             if (!_pd[name])
                 _pd[name] = {};
+            else
+                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = v;
         }
         return _pd;
@@ -309,6 +311,8 @@ PluginComponent {
             var v = entry.substring(colon + 1);
             if (!_pd[name])
                 _pd[name] = {};
+            else
+                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = v;
         }
         return _pd;
@@ -477,6 +481,8 @@ PluginComponent {
                     var csv1 = blk1.substring(c1 + 1);
                     if (!_pd1[pname1])
                         _pd1[pname1] = {};
+                    else
+                        _pd1[pname1] = Object.assign({}, _pd1[pname1]);
                     var parts1 = csv1.split(",");
                     var arr1 = [];
                     for (var di = 0; di < 7; di++)
@@ -499,6 +505,8 @@ PluginComponent {
                     var csv2 = blk2.substring(c2 + 1);
                     if (!_pd2[pname2])
                         _pd2[pname2] = {};
+                    else
+                        _pd2[pname2] = Object.assign({}, _pd2[pname2]);
                     var parts2 = csv2.split(",");
                     var arr2 = [];
                     for (var dci = 0; dci < 7; dci++)
@@ -521,6 +529,8 @@ PluginComponent {
                     var mcsv = blk3.substring(c3 + 1);
                     if (!_pd3[pname3])
                         _pd3[pname3] = {};
+                    else
+                        _pd3[pname3] = Object.assign({}, _pd3[pname3]);
                     var wms = [];
                     if (mcsv.length > 0) {
                         var mentries = mcsv.split(",");
@@ -743,6 +753,14 @@ PluginComponent {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
                 onClicked: profileDropdownPopup.visible = !profileDropdownPopup.visible
+            }
+
+            MouseArea {
+                id: profileDropdownOverlay
+                visible: profileDropdownPopup.visible
+                anchors.fill: root
+                z: 99
+                onClicked: profileDropdownPopup.visible = false
             }
 
             Rectangle {

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -287,18 +287,14 @@ PluginComponent {
             var v = isFloat ? (parseFloat(entry.substring(colon + 1)) || 0) : (parseInt(entry.substring(colon + 1)) || 0);
             if (!_pd[name])
                 _pd[name] = {};
-            else
-                _pd[name] = Object.assign({}, _pd[name]);
             _pd[name][field] = v;
         }
         return _pd;
     }
 
-    // Helper: parse "name:value,..." for string fields (e.g. reset timestamps).
-    // Uses indexOf(":") so ISO 8601 timestamps with colons are handled correctly —
-    // profile names never contain colons, so first colon is always the delimiter.
-    // An empty value after ":" (e.g. "personal:") is intentionally stored as "" —
-    // it is not an error, it means no reset time for that profile.
+    // Uses indexOf(":") so ISO 8601 timestamps (which contain colons) are parsed correctly —
+    // profile names never contain colons, so the first colon is always the name delimiter.
+    // An empty value after ":" (e.g. "personal:") is stored as "" — means no data for that profile.
     function parseProfileString(val, field) {
         var _pd = Object.assign({}, profileData);
         var entries = val.split(",");
@@ -308,12 +304,25 @@ PluginComponent {
             if (colon < 0)
                 continue;
             var name = entry.substring(0, colon);
-            var v = entry.substring(colon + 1);
             if (!_pd[name])
                 _pd[name] = {};
-            else
-                _pd[name] = Object.assign({}, _pd[name]);
-            _pd[name][field] = v;
+            _pd[name][field] = entry.substring(colon + 1);
+        }
+        return _pd;
+    }
+
+    function parseProfileBool(val, field) {
+        var _pd = Object.assign({}, profileData);
+        var entries = val.split(",");
+        for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            var colon = entry.indexOf(":");
+            if (colon < 0)
+                continue;
+            var name = entry.substring(0, colon);
+            if (!_pd[name])
+                _pd[name] = {};
+            _pd[name][field] = entry.substring(colon + 1) === "true";
         }
         return _pd;
     }
@@ -466,7 +475,7 @@ PluginComponent {
             profileData = parseProfileString(val, "sevenDayReset");
             break;
         case "PROFILE_EXTRA_USAGE":
-            profileData = parseProfileString(val, "extraUsageEnabled");
+            profileData = parseProfileBool(val, "extraUsageEnabled");
             break;
         case "PROFILE_DAILY":
             {
@@ -1242,7 +1251,7 @@ PluginComponent {
                                     if (root.hoveredDay < 0)
                                         return "";
                                     var t = root.formatTokens(root.dailyTokens[root.hoveredDay]);
-                                    return root.selectedProfile !== "all" ? t + " total" : t;
+                                    return root.selectedProfile !== "all" ? t + " " + root.tr("total") : t;
                                 }
                                 font.pixelSize: 11
                                 font.weight: Font.DemiBold

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Weekly activity bar chart (Monday–Sunday) with interactive hover tooltips (token count + cost)
   - Per-model token usage for the current calendar week with dynamic model family detection
   - All-time session and message statistics
+- **CCS profile breakdown** — automatically discovers [CCS](https://github.com/AvengeMedia/ccs) instances in `~/.ccs/instances/` and shows per-profile token/cost stats with a hybrid profile selector (tabs for up to 4 profiles, dropdown for more)
+  - Profile overlay on the daily activity chart: grey bars show total usage, colored bars show the selected profile's share
+  - Tooltip shows both total and per-profile token counts when a profile is selected
 - **Automatic subscription detection** via the Anthropic OAuth API
 - **Dynamic model pricing** — new Anthropic model families are detected automatically, no code changes needed
 - **Currency support** — costs displayed in EUR for French locale, USD otherwise (exchange rate from ECB via [Frankfurter](https://www.frankfurter.app/))
@@ -57,7 +60,7 @@ The plugin runs a lightweight bash script at the configured interval that:
 
 1. Reads your OAuth token from `~/.claude/.credentials.json`
 2. Queries the Anthropic usage API for current rate limit status
-3. Parses local JSONL session files for token consumption statistics
+3. Scans `~/.claude/projects/` (default profile) and any `~/.ccs/instances/*/projects/` directories (CCS profiles) for token consumption statistics — each profile is processed in parallel
 4. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
 
 API usage responses are cached for 2 minutes (`~/.claude/usage-cache.json`) to avoid rate limiting, with stale fallback on errors.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Weekly activity bar chart (Monday–Sunday) with interactive hover tooltips (token count + cost)
   - Per-model token usage for the current calendar week with dynamic model family detection
   - All-time session and message statistics
-- **CCS profile breakdown** — automatically discovers [CCS](https://github.com/AvengeMedia/ccs) instances in `~/.ccs/instances/` and shows per-profile token/cost stats with a hybrid profile selector (tabs for up to 4 profiles, dropdown for more)
+- **CCS profile breakdown** — automatically discovers [CCS](https://github.com/kaitranntt/ccs) instances in `~/.ccs/instances/` and shows per-profile token/cost stats with a hybrid profile selector (tabs for up to 4 profiles, dropdown for more)
   - Profile overlay on the daily activity chart: grey bars show total usage, colored bars show the selected profile's share
   - Tooltip shows both total and per-profile token counts when a profile is selected
 - **Automatic subscription detection** via the Anthropic OAuth API

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
 CLAUDE_DIR="${HOME}/.claude"
 CREDENTIALS="${CLAUDE_DIR}/.credentials.json"
 STATS_CACHE="${CLAUDE_DIR}/stats-cache.json"
@@ -108,6 +111,100 @@ if [ -n "$PRICING_JSON" ]; then
     USD_EUR_RATE=$(echo "$PRICING_JSON" | jq -r '.usd_eur_rate // 0' 2>/dev/null || echo "0")
 fi
 
+# --- Per-profile token counting ---
+# Usage: count_profile_tokens <projects_dir> <tmpfile>
+# Writes WEEK_TOKENS=N, WEEK_MESSAGES=N, ... to tmpfile
+count_profile_tokens() {
+    local proj_dir="$1"
+    local out_file="$2"
+
+    # Day dates for the calendar week (same logic as outer scope)
+    local day_dates=""
+    for i in $(seq 0 6); do
+        local d
+        d=$(date -d "$WEEK_START + ${i} days" +%Y-%m-%d)
+        day_dates="${day_dates:+${day_dates},}${d}"
+    done
+
+    find "$proj_dir" -name "*.jsonl" -mtime -31 -exec cat {} + 2>/dev/null \
+        | jq -r -R 'fromjson? | select(.type == "assistant") | "\(.timestamp[:10]) \(.message.model // "unknown") \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0) \(.message.usage.cache_read_input_tokens // 0) \(.message.usage.cache_creation_input_tokens // 0) \(.sessionId // "unknown")"' \
+        | awk -v week_start="$WEEK_START" -v month_start="$MONTH_START" -v today="$TODAY" -v day_dates="$day_dates" -v pricing="$PRICING_AWK" '
+        BEGIN {
+            split(day_dates, dates, ",")
+            has_pricing = 0
+            if (pricing != "") {
+                n = split(pricing, pmodels, ",")
+                for (i = 1; i <= n; i++) {
+                    split(pmodels[i], pp, ":")
+                    price_in[pp[1]] = pp[2] + 0
+                    price_out[pp[1]] = pp[3] + 0
+                    price_cr[pp[1]] = pp[4] + 0
+                    price_cw[pp[1]] = pp[5] + 0
+                }
+                has_pricing = 1
+            }
+        }
+        {
+            date = $1; model = $2
+            inp = $3 + 0; out = $4 + 0; cr = $5 + 0; cw = $6 + 0
+            sess = $7
+            total = inp + out + cr + cw
+
+            n_parts = split(model, mparts, "-")
+            family = (n_parts >= 3 && mparts[1] == "claude") ? mparts[2] : model
+
+            day[date] += total
+            if (date >= week_start) {
+                week_model[family] += total
+                week_tokens += total
+                week_msgs++
+                week_sess[sess] = 1
+            }
+            if (date >= month_start) month_tokens += total
+
+            if (has_pricing && (family in price_in)) {
+                cost = inp * price_in[family] + out * price_out[family] + cr * price_cr[family] + cw * price_cw[family]
+                day_cost[date] += cost
+                if (date >= week_start) week_cost += cost
+                if (date >= month_start) month_cost += cost
+            }
+        }
+        END {
+            printf "WEEK_TOKENS=%d\n", week_tokens + 0
+            printf "WEEK_MESSAGES=%d\n", week_msgs + 0
+            n = 0; for (s in week_sess) n++
+            printf "WEEK_SESSIONS=%d\n", n
+            printf "MONTH_TOKENS=%d\n", month_tokens + 0
+
+            daily = ""
+            for (i = 1; i <= 7; i++) {
+                val = (dates[i] in day) ? day[dates[i]] : 0
+                daily = daily (i > 1 ? "," : "") val + 0
+            }
+            printf "DAILY=%s\n", daily
+
+            models = ""
+            first = 1
+            for (m in week_model) {
+                if (week_model[m] > 0) {
+                    models = models (first ? "" : ",") m "=" week_model[m]
+                    first = 0
+                }
+            }
+            printf "WEEK_MODELS=%s\n", models
+
+            daily_costs = ""
+            for (i = 1; i <= 7; i++) {
+                val = (dates[i] in day_cost) ? day_cost[dates[i]] : 0
+                daily_costs = daily_costs (i > 1 ? "," : "") sprintf("%.2f", val)
+            }
+            printf "DAILY_COSTS=%s\n", daily_costs
+            printf "TODAY_COST=%.2f\n", (today in day_cost) ? day_cost[today] : 0
+            printf "WEEK_COST=%.2f\n", week_cost + 0
+            printf "MONTH_COST=%.2f\n", month_cost + 0
+        }' > "$out_file" 2>/dev/null || true
+}
+
 # --- Subscription & API Usage (with cache to avoid rate limits) ---
 if [ -f "$CREDENTIALS" ]; then
     SUBSCRIPTION_TYPE=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$CREDENTIALS")
@@ -155,111 +252,133 @@ if [ -f "$CREDENTIALS" ]; then
 fi
 
 # --- Token consumption from JSONL session files ---
+# Collect profile directories: default + CCS instances
+PROFILE_DIRS=()
+PROFILE_NAMES=()
+
 if [ -d "$PROJECTS_DIR" ]; then
-    # Calendar week dates: Monday (index 1) to Sunday (index 7)
-    DAY_DATES=""
-    for i in $(seq 0 6); do
-        d=$(date -d "$WEEK_START + ${i} days" +%Y-%m-%d)
-        DAY_DATES="${DAY_DATES:+${DAY_DATES},}${d}"
-    done
-
-    # Single pass: extract granular tokens per message, aggregate with awk
-    while IFS='=' read -r key value; do
-        case "$key" in
-            WEEK_TOKENS) WEEK_TOKENS="$value" ;;
-            WEEK_MESSAGES) WEEK_MESSAGES="$value" ;;
-            WEEK_SESSIONS) WEEK_SESSIONS="$value" ;;
-            MONTH_TOKENS) MONTH_TOKENS="$value" ;;
-            DAILY) DAILY="$value" ;;
-            WEEK_MODELS) WEEK_MODELS="$value" ;;
-            TODAY_COST) TODAY_COST="$value" ;;
-            WEEK_COST) WEEK_COST="$value" ;;
-            MONTH_COST) MONTH_COST="$value" ;;
-            DAILY_COSTS) DAILY_COSTS="$value" ;;
-        esac
-    done < <(find "$PROJECTS_DIR" -name "*.jsonl" -mtime -31 -exec cat {} + 2>/dev/null \
-        | jq -r -R 'fromjson? | select(.type == "assistant") | "\(.timestamp[:10]) \(.message.model // "unknown") \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0) \(.message.usage.cache_read_input_tokens // 0) \(.message.usage.cache_creation_input_tokens // 0) \(.sessionId // "unknown")"' \
-        | awk -v week_start="$WEEK_START" -v month_start="$MONTH_START" -v today="$TODAY" -v day_dates="$DAY_DATES" -v pricing="$PRICING_AWK" '
-        BEGIN {
-            split(day_dates, dates, ",")
-            # Parse pricing: "opus:in:out:cr:cw,sonnet:in:out:cr:cw,haiku:in:out:cr:cw"
-            has_pricing = 0
-            if (pricing != "") {
-                n = split(pricing, pmodels, ",")
-                for (i = 1; i <= n; i++) {
-                    split(pmodels[i], pp, ":")
-                    price_in[pp[1]] = pp[2] + 0
-                    price_out[pp[1]] = pp[3] + 0
-                    price_cr[pp[1]] = pp[4] + 0
-                    price_cw[pp[1]] = pp[5] + 0
-                }
-                has_pricing = 1
-            }
-        }
-        {
-            date = $1; model = $2
-            inp = $3 + 0; out = $4 + 0; cr = $5 + 0; cw = $6 + 0
-            sess = $7
-            total = inp + out + cr + cw
-
-            # Extract family from model name (claude-{family}-{version...})
-            n_parts = split(model, mparts, "-")
-            family = (n_parts >= 3 && mparts[1] == "claude") ? mparts[2] : model
-
-            # Token aggregation (same as before)
-            day[date] += total
-            if (date >= week_start) {
-                week_model[family] += total
-                week_tokens += total
-                week_msgs++
-                week_sess[sess] = 1
-            }
-            if (date >= month_start) month_tokens += total
-
-            # Cost calculation
-            if (has_pricing && (family in price_in)) {
-                cost = inp * price_in[family] + out * price_out[family] + cr * price_cr[family] + cw * price_cw[family]
-                day_cost[date] += cost
-                if (date >= week_start) week_cost += cost
-                if (date >= month_start) month_cost += cost
-            }
-        }
-        END {
-            printf "WEEK_TOKENS=%d\n", week_tokens + 0
-            printf "WEEK_MESSAGES=%d\n", week_msgs + 0
-            n = 0; for (s in week_sess) n++
-            printf "WEEK_SESSIONS=%d\n", n
-            printf "MONTH_TOKENS=%d\n", month_tokens + 0
-
-            daily = ""
-            for (i = 1; i <= 7; i++) {
-                val = (dates[i] in day) ? day[dates[i]] : 0
-                daily = daily (i > 1 ? "," : "") val + 0
-            }
-            printf "DAILY=%s\n", daily
-
-            models = ""
-            first = 1
-            for (m in week_model) {
-                if (week_model[m] > 0) {
-                    models = models (first ? "" : ",") m ":" week_model[m]
-                    first = 0
-                }
-            }
-            printf "WEEK_MODELS=%s\n", models
-
-            # Cost outputs
-            daily_costs = ""
-            for (i = 1; i <= 7; i++) {
-                val = (dates[i] in day_cost) ? day_cost[dates[i]] : 0
-                daily_costs = daily_costs (i > 1 ? "," : "") sprintf("%.2f", val)
-            }
-            printf "DAILY_COSTS=%s\n", daily_costs
-            printf "TODAY_COST=%.2f\n", (today in day_cost) ? day_cost[today] : 0
-            printf "WEEK_COST=%.2f\n", week_cost + 0
-            printf "MONTH_COST=%.2f\n", month_cost + 0
-        }')
+    PROFILE_DIRS+=("$PROJECTS_DIR")
+    PROFILE_NAMES+=("default")
 fi
+
+CCS_INSTANCES_DIR="${HOME}/.ccs/instances"
+if [ -d "$CCS_INSTANCES_DIR" ]; then
+    for inst in "$CCS_INSTANCES_DIR"/*/; do
+        [ -d "${inst}projects" ] || continue
+        name=$(basename "$inst")
+        PROFILE_DIRS+=("${inst}projects")
+        PROFILE_NAMES+=("$name")
+    done
+fi
+
+# Run count_profile_tokens in parallel for each profile
+TMPFILES=()
+PIDS=()
+for idx in "${!PROFILE_DIRS[@]}"; do
+    tmpf=$(mktemp "$TMPDIR_ROOT/profile_XXXXXX")
+    TMPFILES+=("$tmpf")
+    ( count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf" ) &
+    PIDS+=("$!")
+done
+
+# Wait for all parallel jobs
+for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+done
+
+# Read per-profile results and build aggregate + per-profile output vars
+WEEK_TOKENS=0; WEEK_MESSAGES=0; WEEK_SESSIONS=0; MONTH_TOKENS=0
+DAILY_ARR=(0 0 0 0 0 0 0)
+DAILY_COSTS_ARR=(0.00 0.00 0.00 0.00 0.00 0.00 0.00)
+TODAY_COST="0.00"; WEEK_COST="0.00"; MONTH_COST="0.00"
+
+PROF_WEEK_TOKENS_LIST=""
+PROF_MONTH_TOKENS_LIST=""
+PROF_TODAY_COST_LIST=""
+PROF_WEEK_COST_LIST=""
+PROF_MONTH_COST_LIST=""
+PROF_DAILY_LIST=""
+PROF_DAILY_COSTS_LIST=""
+PROF_WEEK_MODELS_LIST=""
+
+for idx in "${!TMPFILES[@]}"; do
+    tmpf="${TMPFILES[$idx]}"
+    pname="${PROFILE_NAMES[$idx]}"
+    [ -f "$tmpf" ] || continue
+
+    # Read per-profile values
+    p_wt=$(grep "^WEEK_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+    p_wm=$(grep "^WEEK_MESSAGES=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+    p_ws=$(grep "^WEEK_SESSIONS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+    p_mt=$(grep "^MONTH_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+    p_daily=$(grep "^DAILY=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0,0,0,0,0,0,0")
+    p_models=$(grep "^WEEK_MODELS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+    p_dc=$(grep "^DAILY_COSTS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00,0.00,0.00,0.00,0.00,0.00,0.00")
+    p_tc=$(grep "^TODAY_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
+    p_wc=$(grep "^WEEK_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
+    p_mc=$(grep "^MONTH_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
+
+    # Aggregate totals
+    WEEK_TOKENS=$(( WEEK_TOKENS + p_wt ))
+    WEEK_MESSAGES=$(( WEEK_MESSAGES + p_wm ))
+    MONTH_TOKENS=$(( MONTH_TOKENS + p_mt ))
+    WEEK_SESSIONS=$(( WEEK_SESSIONS + p_ws ))
+
+    # Aggregate daily arrays (element-wise addition via awk)
+    DAILY=$(echo "$p_daily" | awk -v cur="$(IFS=,; echo "${DAILY_ARR[*]}")" '
+        BEGIN { split(cur, a, ",") }
+        { split($0, b, ","); for(i=1;i<=7;i++) a[i]+=b[i]+0 }
+        END { for(i=1;i<=7;i++) printf "%s%s", (i>1?",":""), a[i]+0; print "" }
+    ')
+    IFS=',' read -ra DAILY_ARR <<< "$DAILY"
+
+    # Aggregate costs (awk float addition)
+    TODAY_COST=$(awk "BEGIN {printf \"%.2f\", $TODAY_COST + $p_tc}")
+    WEEK_COST=$(awk "BEGIN {printf \"%.2f\", $WEEK_COST + $p_wc}")
+    MONTH_COST=$(awk "BEGIN {printf \"%.2f\", $MONTH_COST + $p_mc}")
+
+    DAILY_COSTS=$(echo "$p_dc" | awk -v cur="$(IFS=,; echo "${DAILY_COSTS_ARR[*]}")" '
+        BEGIN { split(cur, a, ",") }
+        { split($0, b, ","); for(i=1;i<=7;i++) a[i]+=b[i]+0 }
+        END { for(i=1;i<=7;i++) printf "%s%.2f", (i>1?",":""), a[i]+0; print "" }
+    ')
+    IFS=',' read -ra DAILY_COSTS_ARR <<< "$DAILY_COSTS"
+
+    # Per-profile lists
+    PROF_WEEK_TOKENS_LIST="${PROF_WEEK_TOKENS_LIST:+${PROF_WEEK_TOKENS_LIST},}${pname}:${p_wt}"
+    PROF_MONTH_TOKENS_LIST="${PROF_MONTH_TOKENS_LIST:+${PROF_MONTH_TOKENS_LIST},}${pname}:${p_mt}"
+    PROF_TODAY_COST_LIST="${PROF_TODAY_COST_LIST:+${PROF_TODAY_COST_LIST},}${pname}:${p_tc}"
+    PROF_WEEK_COST_LIST="${PROF_WEEK_COST_LIST:+${PROF_WEEK_COST_LIST},}${pname}:${p_wc}"
+    PROF_MONTH_COST_LIST="${PROF_MONTH_COST_LIST:+${PROF_MONTH_COST_LIST},}${pname}:${p_mc}"
+    PROF_DAILY_LIST="${PROF_DAILY_LIST:+${PROF_DAILY_LIST}|}${pname}:${p_daily}"
+    PROF_DAILY_COSTS_LIST="${PROF_DAILY_COSTS_LIST:+${PROF_DAILY_COSTS_LIST}|}${pname}:${p_dc}"
+    PROF_WEEK_MODELS_LIST="${PROF_WEEK_MODELS_LIST:+${PROF_WEEK_MODELS_LIST}|}${pname}:${p_models}"
+
+    rm -f "$tmpf"
+done
+
+# Reconstruct WEEK_MODELS aggregate from per-profile data (sum same-family tokens)
+WEEK_MODELS=$(echo "$PROF_WEEK_MODELS_LIST" | tr '|' '\n' | cut -d: -f2- | tr ',' '\n' | grep '=' | \
+    awk -F= '{ acc[$1]+=$2 } END { first=1; for(m in acc) { printf "%s%s=%d", (first?"":","),(m),(acc[m]+0); first=0 } print "" }')
+
+# Build final DAILY and DAILY_COSTS strings
+DAILY=$(IFS=,; printf '%s' "${DAILY_ARR[*]}")
+DAILY_COSTS=$(IFS=,; printf '%s' "${DAILY_COSTS_ARR[*]}")
+
+# Build PROFILES list
+PROFILES=$(IFS=,; echo "${PROFILE_NAMES[*]}")
+
+# Rate limit per profile (same values for all — shared credentials)
+PROF_FIVE_HOUR_UTIL=""
+PROF_SEVEN_DAY_UTIL=""
+PROF_FIVE_HOUR_RESET_LIST=""
+PROF_SEVEN_DAY_RESET_LIST=""
+for pname in "${PROFILE_NAMES[@]}"; do
+    PROF_FIVE_HOUR_UTIL="${PROF_FIVE_HOUR_UTIL:+${PROF_FIVE_HOUR_UTIL},}${pname}:${FIVE_HOUR_UTIL}"
+    PROF_SEVEN_DAY_UTIL="${PROF_SEVEN_DAY_UTIL:+${PROF_SEVEN_DAY_UTIL},}${pname}:${SEVEN_DAY_UTIL}"
+    PROF_FIVE_HOUR_RESET_LIST="${PROF_FIVE_HOUR_RESET_LIST:+${PROF_FIVE_HOUR_RESET_LIST},}${pname}:${FIVE_HOUR_RESET}"
+    PROF_SEVEN_DAY_RESET_LIST="${PROF_SEVEN_DAY_RESET_LIST:+${PROF_SEVEN_DAY_RESET_LIST},}${pname}:${SEVEN_DAY_RESET}"
+done
 
 # --- All-time from stats cache (supplementary) ---
 if [ -f "$STATS_CACHE" ]; then
@@ -291,3 +410,16 @@ echo "WEEK_COST=${WEEK_COST}"
 echo "MONTH_COST=${MONTH_COST}"
 echo "DAILY_COSTS=${DAILY_COSTS}"
 echo "USD_EUR_RATE=${USD_EUR_RATE}"
+echo "PROFILES=${PROFILES}"
+echo "PROFILE_WEEK_TOKENS=${PROF_WEEK_TOKENS_LIST}"
+echo "PROFILE_MONTH_TOKENS=${PROF_MONTH_TOKENS_LIST}"
+echo "PROFILE_TODAY_COST=${PROF_TODAY_COST_LIST}"
+echo "PROFILE_WEEK_COST=${PROF_WEEK_COST_LIST}"
+echo "PROFILE_MONTH_COST=${PROF_MONTH_COST_LIST}"
+echo "PROFILE_DAILY=${PROF_DAILY_LIST}"
+echo "PROFILE_DAILY_COSTS=${PROF_DAILY_COSTS_LIST}"
+echo "PROFILE_WEEK_MODELS=${PROF_WEEK_MODELS_LIST}"
+echo "PROFILE_FIVE_HOUR_UTIL=${PROF_FIVE_HOUR_UTIL}"
+echo "PROFILE_SEVEN_DAY_UTIL=${PROF_SEVEN_DAY_UTIL}"
+echo "PROFILE_FIVE_HOUR_RESET=${PROF_FIVE_HOUR_RESET_LIST}"
+echo "PROFILE_SEVEN_DAY_RESET=${PROF_SEVEN_DAY_RESET_LIST}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -205,60 +205,80 @@ count_profile_tokens() {
         }' > "$out_file" 2>/dev/null || true
 }
 
-# --- Subscription & API Usage (with cache to avoid rate limits) ---
-if [ -f "$CREDENTIALS" ]; then
-    SUBSCRIPTION_TYPE=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$CREDENTIALS")
-    RATE_LIMIT_TIER=$(jq -r '.claudeAiOauth.rateLimitTier // "unknown"' "$CREDENTIALS")
+# --- Per-profile credentials + API usage fetcher ---
+# Usage: fetch_profile_usage <credentials_file> <cache_file> <out_tmpfile>
+# Writes SUBSCRIPTION_TYPE, RATE_LIMIT_TIER, FIVE_HOUR_UTIL, FIVE_HOUR_RESET,
+#        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED to out_tmpfile
+fetch_profile_usage() {
+    local creds_file="$1"
+    local cache_file="$2"
+    local out_file="$3"
 
-    # Check if cached usage data is still fresh
-    USE_CACHE=false
-    if [ -f "$USAGE_CACHE" ]; then
-        cache_ts=$(jq -r '.cached_at // 0' "$USAGE_CACHE" 2>/dev/null || echo 0)
-        now_ts=$(date +%s)
-        age=$(( now_ts - cache_ts ))
-        if [ "$age" -lt "$USAGE_CACHE_TTL" ]; then
-            USE_CACHE=true
-        fi
+    local sub_type="unknown"
+    local tier="unknown"
+    local five_util=0 five_reset="" seven_util=0 seven_reset="" extra="false"
+
+    if [ ! -f "$creds_file" ]; then
+        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
+            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+        return
     fi
 
-    if [ "$USE_CACHE" = true ]; then
-        API_RESPONSE=$(jq -r '.data' "$USAGE_CACHE" 2>/dev/null || echo '{}')
+    sub_type=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$creds_file" 2>/dev/null || echo "unknown")
+    tier=$(jq -r '.claudeAiOauth.rateLimitTier // "unknown"' "$creds_file" 2>/dev/null || echo "unknown")
+
+    # Check cache freshness
+    local api_resp="{}"
+    local use_cache=false
+    if [ -f "$cache_file" ]; then
+        local cache_ts now_ts age
+        cache_ts=$(jq -r '.cached_at // 0' "$cache_file" 2>/dev/null || echo 0)
+        now_ts=$(date +%s)
+        age=$(( now_ts - cache_ts ))
+        [ "$age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
+    fi
+
+    if [ "$use_cache" = true ]; then
+        api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
     else
-        TOKEN=$(jq -r '.claudeAiOauth.accessToken // ""' "$CREDENTIALS")
-        if [ -n "$TOKEN" ]; then
-            API_RESPONSE=$(curl -s --max-time 5 \
-                -H "Authorization: Bearer $TOKEN" \
+        local token
+        token=$(jq -r '.claudeAiOauth.accessToken // ""' "$creds_file" 2>/dev/null || echo "")
+        if [ -n "$token" ]; then
+            api_resp=$(curl -s --max-time 5 \
+                -H "Authorization: Bearer $token" \
                 -H "Accept: application/json" \
                 -H "Content-Type: application/json" \
                 -H "User-Agent: claude-code/${CLAUDE_VERSION}" \
                 -H "anthropic-beta: oauth-2025-04-20" \
                 "https://api.anthropic.com/api/oauth/usage" 2>/dev/null || echo '{}')
 
-            # Cache successful responses (no error field)
-            if echo "$API_RESPONSE" | jq -e '.five_hour' >/dev/null 2>&1; then
-                jq -n --argjson data "$API_RESPONSE" '{cached_at: (now | floor), data: $data}' > "$USAGE_CACHE" 2>/dev/null
-            elif [ -f "$USAGE_CACHE" ]; then
-                # On rate limit or error, use stale cache if available
-                API_RESPONSE=$(jq -r '.data' "$USAGE_CACHE" 2>/dev/null || echo '{}')
+            if echo "$api_resp" | jq -e '.five_hour' >/dev/null 2>&1; then
+                jq -n --argjson data "$api_resp" '{cached_at: (now | floor), data: $data}' > "$cache_file" 2>/dev/null || true
+            elif [ -f "$cache_file" ]; then
+                api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
             fi
         fi
     fi
 
-    FIVE_HOUR_UTIL=$(echo "$API_RESPONSE" | jq -r '.five_hour.utilization // 0')
-    FIVE_HOUR_RESET=$(echo "$API_RESPONSE" | jq -r '.five_hour.resets_at // ""')
-    SEVEN_DAY_UTIL=$(echo "$API_RESPONSE" | jq -r '.seven_day.utilization // 0')
-    SEVEN_DAY_RESET=$(echo "$API_RESPONSE" | jq -r '.seven_day.resets_at // ""')
-    EXTRA_USAGE_ENABLED=$(echo "$API_RESPONSE" | jq -r '.extra_usage.is_enabled // false')
-fi
+    five_util=$(echo "$api_resp" | jq -r '.five_hour.utilization // 0')
+    five_reset=$(echo "$api_resp" | jq -r '.five_hour.resets_at // ""')
+    seven_util=$(echo "$api_resp" | jq -r '.seven_day.utilization // 0')
+    seven_reset=$(echo "$api_resp" | jq -r '.seven_day.resets_at // ""')
+    extra=$(echo "$api_resp" | jq -r '.extra_usage.is_enabled // false')
 
-# --- Token consumption from JSONL session files ---
-# Collect profile directories: default + CCS instances
+    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
+        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+}
+
+# --- Collect profile list: default + CCS instances ---
 PROFILE_DIRS=()
 PROFILE_NAMES=()
+PROFILE_CREDS=()  # credentials file per profile
 
 if [ -d "$PROJECTS_DIR" ]; then
     PROFILE_DIRS+=("$PROJECTS_DIR")
     PROFILE_NAMES+=("default")
+    PROFILE_CREDS+=("$CREDENTIALS")
 fi
 
 CCS_INSTANCES_DIR="${HOME}/.ccs/instances"
@@ -268,25 +288,41 @@ if [ -d "$CCS_INSTANCES_DIR" ]; then
         name=$(basename "$inst")
         PROFILE_DIRS+=("${inst}projects")
         PROFILE_NAMES+=("$name")
+        PROFILE_CREDS+=("${inst}.credentials.json")
     done
 fi
 
-# Run count_profile_tokens in parallel for each profile
-TMPFILES=()
+# --- Run token counting + usage fetch in parallel for each profile ---
+TMPFILES=()      # token stats tmpfile per profile
+USAGE_TMPFILES=() # usage/subscription tmpfile per profile
 PIDS=()
+
 for idx in "${!PROFILE_DIRS[@]}"; do
     tmpf=$(mktemp "$TMPDIR_ROOT/profile_XXXXXX")
+    usage_tmpf=$(mktemp "$TMPDIR_ROOT/usage_XXXXXX")
     TMPFILES+=("$tmpf")
-    ( count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf" ) &
+    USAGE_TMPFILES+=("$usage_tmpf")
+
+    # Per-profile usage cache: default uses the shared cache, CCS instances get their own
+    pname="${PROFILE_NAMES[$idx]}"
+    if [ "$pname" = "default" ]; then
+        prof_cache="$USAGE_CACHE"
+    else
+        prof_cache="${CLAUDE_DIR}/usage-cache-${pname}.json"
+    fi
+
+    (
+        count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf"
+        fetch_profile_usage "${PROFILE_CREDS[$idx]}" "$prof_cache" "$usage_tmpf"
+    ) &
     PIDS+=("$!")
 done
 
-# Wait for all parallel jobs
 for pid in "${PIDS[@]}"; do
     wait "$pid" || true
 done
 
-# Read per-profile results and build aggregate + per-profile output vars
+# --- Read per-profile results and build aggregate + per-profile output vars ---
 WEEK_TOKENS=0; WEEK_MESSAGES=0; WEEK_SESSIONS=0; MONTH_TOKENS=0
 DAILY_ARR=(0 0 0 0 0 0 0)
 DAILY_COSTS_ARR=(0.00 0.00 0.00 0.00 0.00 0.00 0.00)
@@ -300,13 +336,21 @@ PROF_MONTH_COST_LIST=""
 PROF_DAILY_LIST=""
 PROF_DAILY_COSTS_LIST=""
 PROF_WEEK_MODELS_LIST=""
+PROF_SUBSCRIPTION_LIST=""
+PROF_TIER_LIST=""
+PROF_FIVE_HOUR_UTIL=""
+PROF_SEVEN_DAY_UTIL=""
+PROF_FIVE_HOUR_RESET_LIST=""
+PROF_SEVEN_DAY_RESET_LIST=""
+PROF_EXTRA_USAGE_LIST=""
 
 for idx in "${!TMPFILES[@]}"; do
     tmpf="${TMPFILES[$idx]}"
+    usage_tmpf="${USAGE_TMPFILES[$idx]}"
     pname="${PROFILE_NAMES[$idx]}"
     [ -f "$tmpf" ] || continue
 
-    # Read per-profile values
+    # Read per-profile token stats
     p_wt=$(grep "^WEEK_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
     p_wm=$(grep "^WEEK_MESSAGES=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
     p_ws=$(grep "^WEEK_SESSIONS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
@@ -318,7 +362,31 @@ for idx in "${!TMPFILES[@]}"; do
     p_wc=$(grep "^WEEK_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
     p_mc=$(grep "^MONTH_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
 
-    # Aggregate totals
+    # Read per-profile usage/subscription
+    p_sub="unknown"; p_tier="unknown"
+    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"
+    if [ -f "$usage_tmpf" ]; then
+        p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "unknown")
+        p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "unknown")
+        p_5u=$(grep "^FIVE_HOUR_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+        p_5r=$(grep "^FIVE_HOUR_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "")
+        p_7u=$(grep "^SEVEN_DAY_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
+        p_7r=$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "")
+        p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "false")
+    fi
+
+    # Default profile drives the top-level aggregate fields
+    if [ "$pname" = "default" ]; then
+        SUBSCRIPTION_TYPE="$p_sub"
+        RATE_LIMIT_TIER="$p_tier"
+        FIVE_HOUR_UTIL="$p_5u"
+        FIVE_HOUR_RESET="$p_5r"
+        SEVEN_DAY_UTIL="$p_7u"
+        SEVEN_DAY_RESET="$p_7r"
+        EXTRA_USAGE_ENABLED="$p_extra"
+    fi
+
+    # Aggregate token totals
     WEEK_TOKENS=$(( WEEK_TOKENS + p_wt ))
     WEEK_MESSAGES=$(( WEEK_MESSAGES + p_wm ))
     MONTH_TOKENS=$(( MONTH_TOKENS + p_mt ))
@@ -332,7 +400,6 @@ for idx in "${!TMPFILES[@]}"; do
     ')
     IFS=',' read -ra DAILY_ARR <<< "$DAILY"
 
-    # Aggregate costs (awk float addition)
     TODAY_COST=$(awk "BEGIN {printf \"%.2f\", $TODAY_COST + $p_tc}")
     WEEK_COST=$(awk "BEGIN {printf \"%.2f\", $WEEK_COST + $p_wc}")
     MONTH_COST=$(awk "BEGIN {printf \"%.2f\", $MONTH_COST + $p_mc}")
@@ -344,7 +411,7 @@ for idx in "${!TMPFILES[@]}"; do
     ')
     IFS=',' read -ra DAILY_COSTS_ARR <<< "$DAILY_COSTS"
 
-    # Per-profile lists
+    # Per-profile token lists
     PROF_WEEK_TOKENS_LIST="${PROF_WEEK_TOKENS_LIST:+${PROF_WEEK_TOKENS_LIST},}${pname}:${p_wt}"
     PROF_MONTH_TOKENS_LIST="${PROF_MONTH_TOKENS_LIST:+${PROF_MONTH_TOKENS_LIST},}${pname}:${p_mt}"
     PROF_TODAY_COST_LIST="${PROF_TODAY_COST_LIST:+${PROF_TODAY_COST_LIST},}${pname}:${p_tc}"
@@ -354,30 +421,16 @@ for idx in "${!TMPFILES[@]}"; do
     PROF_DAILY_COSTS_LIST="${PROF_DAILY_COSTS_LIST:+${PROF_DAILY_COSTS_LIST}|}${pname}:${p_dc}"
     PROF_WEEK_MODELS_LIST="${PROF_WEEK_MODELS_LIST:+${PROF_WEEK_MODELS_LIST}|}${pname}:${p_models}"
 
-    rm -f "$tmpf"
-done
+    # Per-profile subscription/usage lists
+    PROF_SUBSCRIPTION_LIST="${PROF_SUBSCRIPTION_LIST:+${PROF_SUBSCRIPTION_LIST},}${pname}:${p_sub}"
+    PROF_TIER_LIST="${PROF_TIER_LIST:+${PROF_TIER_LIST},}${pname}:${p_tier}"
+    PROF_FIVE_HOUR_UTIL="${PROF_FIVE_HOUR_UTIL:+${PROF_FIVE_HOUR_UTIL},}${pname}:${p_5u}"
+    PROF_SEVEN_DAY_UTIL="${PROF_SEVEN_DAY_UTIL:+${PROF_SEVEN_DAY_UTIL},}${pname}:${p_7u}"
+    PROF_FIVE_HOUR_RESET_LIST="${PROF_FIVE_HOUR_RESET_LIST:+${PROF_FIVE_HOUR_RESET_LIST},}${pname}:${p_5r}"
+    PROF_SEVEN_DAY_RESET_LIST="${PROF_SEVEN_DAY_RESET_LIST:+${PROF_SEVEN_DAY_RESET_LIST},}${pname}:${p_7r}"
+    PROF_EXTRA_USAGE_LIST="${PROF_EXTRA_USAGE_LIST:+${PROF_EXTRA_USAGE_LIST},}${pname}:${p_extra}"
 
-# Reconstruct WEEK_MODELS aggregate from per-profile data (sum same-family tokens)
-WEEK_MODELS=$(echo "$PROF_WEEK_MODELS_LIST" | tr '|' '\n' | cut -d: -f2- | tr ',' '\n' | grep '=' | \
-    awk -F= '{ acc[$1]+=$2 } END { first=1; for(m in acc) { printf "%s%s=%d", (first?"":","),(m),(acc[m]+0); first=0 } print "" }')
-
-# Build final DAILY and DAILY_COSTS strings
-DAILY=$(IFS=,; printf '%s' "${DAILY_ARR[*]}")
-DAILY_COSTS=$(IFS=,; printf '%s' "${DAILY_COSTS_ARR[*]}")
-
-# Build PROFILES list
-PROFILES=$(IFS=,; echo "${PROFILE_NAMES[*]}")
-
-# Rate limit per profile (same values for all — shared credentials)
-PROF_FIVE_HOUR_UTIL=""
-PROF_SEVEN_DAY_UTIL=""
-PROF_FIVE_HOUR_RESET_LIST=""
-PROF_SEVEN_DAY_RESET_LIST=""
-for pname in "${PROFILE_NAMES[@]}"; do
-    PROF_FIVE_HOUR_UTIL="${PROF_FIVE_HOUR_UTIL:+${PROF_FIVE_HOUR_UTIL},}${pname}:${FIVE_HOUR_UTIL}"
-    PROF_SEVEN_DAY_UTIL="${PROF_SEVEN_DAY_UTIL:+${PROF_SEVEN_DAY_UTIL},}${pname}:${SEVEN_DAY_UTIL}"
-    PROF_FIVE_HOUR_RESET_LIST="${PROF_FIVE_HOUR_RESET_LIST:+${PROF_FIVE_HOUR_RESET_LIST},}${pname}:${FIVE_HOUR_RESET}"
-    PROF_SEVEN_DAY_RESET_LIST="${PROF_SEVEN_DAY_RESET_LIST:+${PROF_SEVEN_DAY_RESET_LIST},}${pname}:${SEVEN_DAY_RESET}"
+    rm -f "$tmpf" "$usage_tmpf"
 done
 
 # --- All-time from stats cache (supplementary) ---
@@ -387,6 +440,13 @@ if [ -f "$STATS_CACHE" ]; then
     FIRST_SESSION=$(jq -r '.firstSessionDate // "unknown"' "$STATS_CACHE" 2>/dev/null || echo "unknown")
     FIRST_SESSION="${FIRST_SESSION%%T*}"
 fi
+
+# Build final strings
+WEEK_MODELS=$(echo "$PROF_WEEK_MODELS_LIST" | tr '|' '\n' | cut -d: -f2- | tr ',' '\n' | grep '=' | \
+    awk -F= '{ acc[$1]+=$2 } END { first=1; for(m in acc) { printf "%s%s=%d", (first?"":","),(m),(acc[m]+0); first=0 } print "" }')
+DAILY=$(IFS=,; printf '%s' "${DAILY_ARR[*]}")
+DAILY_COSTS=$(IFS=,; printf '%s' "${DAILY_COSTS_ARR[*]}")
+PROFILES=$(IFS=,; echo "${PROFILE_NAMES[*]}")
 
 # Output key=value pairs
 echo "SUBSCRIPTION_TYPE=${SUBSCRIPTION_TYPE}"
@@ -411,6 +471,8 @@ echo "MONTH_COST=${MONTH_COST}"
 echo "DAILY_COSTS=${DAILY_COSTS}"
 echo "USD_EUR_RATE=${USD_EUR_RATE}"
 echo "PROFILES=${PROFILES}"
+echo "PROFILE_SUBSCRIPTION=${PROF_SUBSCRIPTION_LIST}"
+echo "PROFILE_TIER=${PROF_TIER_LIST}"
 echo "PROFILE_WEEK_TOKENS=${PROF_WEEK_TOKENS_LIST}"
 echo "PROFILE_MONTH_TOKENS=${PROF_MONTH_TOKENS_LIST}"
 echo "PROFILE_TODAY_COST=${PROF_TODAY_COST_LIST}"
@@ -423,3 +485,4 @@ echo "PROFILE_FIVE_HOUR_UTIL=${PROF_FIVE_HOUR_UTIL}"
 echo "PROFILE_SEVEN_DAY_UTIL=${PROF_SEVEN_DAY_UTIL}"
 echo "PROFILE_FIVE_HOUR_RESET=${PROF_FIVE_HOUR_RESET_LIST}"
 echo "PROFILE_SEVEN_DAY_RESET=${PROF_SEVEN_DAY_RESET_LIST}"
+echo "PROFILE_EXTRA_USAGE=${PROF_EXTRA_USAGE_LIST}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -287,7 +287,8 @@ CCS_INSTANCES_DIR="${HOME}/.ccs/instances"
 if [ -d "$CCS_INSTANCES_DIR" ]; then
     for inst in "$CCS_INSTANCES_DIR"/*/; do
         [ -d "${inst}projects" ] || continue
-        name=$(basename "$inst")
+        name=$(basename "$inst" | tr -d ',|:')
+        [ -z "$name" ] && continue
         PROFILE_DIRS+=("${inst}projects")
         PROFILE_NAMES+=("$name")
         PROFILE_CREDS+=("${inst}.credentials.json")

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -187,6 +187,8 @@ count_profile_tokens() {
             first = 1
             for (m in week_model) {
                 if (week_model[m] > 0) {
+                    # Use "=" as separator (not ":") because model names like
+                    # "claude-3-5-sonnet:thinking" can contain colons.
                     models = models (first ? "" : ",") m "=" week_model[m]
                     first = 0
                 }
@@ -351,28 +353,28 @@ for idx in "${!TMPFILES[@]}"; do
     [ -f "$tmpf" ] || continue
 
     # Read per-profile token stats
-    p_wt=$(grep "^WEEK_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-    p_wm=$(grep "^WEEK_MESSAGES=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-    p_ws=$(grep "^WEEK_SESSIONS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-    p_mt=$(grep "^MONTH_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-    p_daily=$(grep "^DAILY=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0,0,0,0,0,0,0")
+    p_wt=$(grep "^WEEK_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+    p_wm=$(grep "^WEEK_MESSAGES=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+    p_ws=$(grep "^WEEK_SESSIONS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+    p_mt=$(grep "^MONTH_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+    p_daily=$(grep "^DAILY=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0,0,0,0,0,0,0")
     p_models=$(grep "^WEEK_MODELS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "")
-    p_dc=$(grep "^DAILY_COSTS=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00,0.00,0.00,0.00,0.00,0.00,0.00")
-    p_tc=$(grep "^TODAY_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
-    p_wc=$(grep "^WEEK_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
-    p_mc=$(grep "^MONTH_COST=" "$tmpf" 2>/dev/null | cut -d= -f2 || echo "0.00")
+    p_dc=$(grep "^DAILY_COSTS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00,0.00,0.00,0.00,0.00,0.00,0.00")
+    p_tc=$(grep "^TODAY_COST=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00")
+    p_wc=$(grep "^WEEK_COST=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00")
+    p_mc=$(grep "^MONTH_COST=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00")
 
     # Read per-profile usage/subscription
     p_sub="unknown"; p_tier="unknown"
     p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"
     if [ -f "$usage_tmpf" ]; then
-        p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "unknown")
-        p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "unknown")
-        p_5u=$(grep "^FIVE_HOUR_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-        p_5r=$(grep "^FIVE_HOUR_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "")
-        p_7u=$(grep "^SEVEN_DAY_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo 0)
-        p_7r=$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "")
-        p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2 || echo "false")
+        p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
+        p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
+        p_5u=$(grep "^FIVE_HOUR_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+        p_5r=$(grep "^FIVE_HOUR_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+        p_7u=$(grep "^SEVEN_DAY_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+        p_7r=$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+        p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "false")
     fi
 
     # Default profile drives the top-level aggregate fields

--- a/plugin.json
+++ b/plugin.json
@@ -2,21 +2,13 @@
   "id": "claudeCodeUsage",
   "name": "Claude Code Usage",
   "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "Nicolas Bellamy",
   "icon": "monitoring",
   "type": "widget",
-  "capabilities": [
-    "dankbar-widget"
-  ],
+  "capabilities": ["dankbar-widget"],
   "component": "./ClaudeCodeUsageWidget.qml",
   "settings": "./ClaudeCodeUsageSettings.qml",
-  "requires": [
-    "jq",
-    "curl"
-  ],
-  "permissions": [
-    "settings_read",
-    "settings_write"
-  ]
+  "requires": ["jq", "curl"],
+  "permissions": ["settings_read", "settings_write"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "claudeCodeUsage",
   "name": "Claude Code Usage",
   "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "author": "Nicolas Bellamy",
   "icon": "monitoring",
   "type": "widget",

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -104,7 +104,7 @@ WEEK_SESSIONS=$(echo "$OUTPUT2" | grep "^WEEK_SESSIONS=" | cut -d= -f2)
 assert_eq "$WEEK_SESSIONS" "2" "WEEK_SESSIONS=2"
 
 # WEEK_MODELS should contain opus and sonnet
-WEEK_MODELS=$(echo "$OUTPUT2" | grep "^WEEK_MODELS=" | cut -d= -f2)
+WEEK_MODELS=$(echo "$OUTPUT2" | grep "^WEEK_MODELS=" | cut -d= -f2-)
 assert_match "$WEEK_MODELS" "opus" "WEEK_MODELS contains opus"
 assert_match "$WEEK_MODELS" "sonnet" "WEEK_MODELS contains sonnet"
 
@@ -227,6 +227,120 @@ PVEOF
 OUTPUT7=$(run_script "$ENV7")
 TODAY_COST7=$(echo "$OUTPUT7" | grep "^TODAY_COST=" | cut -d= -f2)
 assert_eq "$TODAY_COST7" "0.00" "Cost=0 when model family not in pricing cache"
+
+# ============================================================
+echo "=== Test 8: PROFILES field — default profile always present ==="
+# ============================================================
+ENV8=$(setup_env "test8")
+OUTPUT8=$(run_script "$ENV8")
+
+if echo "$OUTPUT8" | grep -q "^PROFILES="; then
+    pass "PROFILES key present"
+else
+    fail "PROFILES key missing"
+fi
+
+PROFILES8=$(echo "$OUTPUT8" | grep "^PROFILES=" | cut -d= -f2)
+assert_match "$PROFILES8" "default" "PROFILES contains default"
+
+# ============================================================
+echo "=== Test 9: PROFILES discovers CCS instances ==="
+# ============================================================
+ENV9=$(setup_env "test9")
+mkdir -p "$ENV9/.ccs/instances/work/projects/proj1"
+mkdir -p "$ENV9/.ccs/instances/home/projects/proj2"
+
+make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 500 300 0 0 "sess-r" \
+    > "$ENV9/.ccs/instances/work/projects/proj1/test.jsonl"
+
+OUTPUT9=$(run_script "$ENV9")
+
+PROFILES9=$(echo "$OUTPUT9" | grep "^PROFILES=" | cut -d= -f2)
+assert_match "$PROFILES9" "default" "PROFILES contains default (test9)"
+assert_match "$PROFILES9" "work" "PROFILES contains work"
+assert_match "$PROFILES9" "home" "PROFILES contains home"
+
+# ============================================================
+echo "=== Test 10: PROFILE_WEEK_TOKENS format and values ==="
+# ============================================================
+ENV10=$(setup_env "test10")
+mkdir -p "$ENV10/.ccs/instances/work/projects/proj1"
+
+# default: 630 tokens (100+200+50+30+150+100)
+make_jsonl_line "$TODAY" "claude-opus-4-20250514" 100 200 50 30 "sess-a" \
+    > "$ENV10/.claude/projects/test-project/t.jsonl"
+make_jsonl_line "$TODAY" "claude-opus-4-20250514" 150 100 0 0 "sess-a" \
+    >> "$ENV10/.claude/projects/test-project/t.jsonl"
+
+# work: 800 tokens (500+300)
+make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 500 300 0 0 "sess-r" \
+    > "$ENV10/.ccs/instances/work/projects/proj1/t.jsonl"
+
+OUTPUT10=$(run_script "$ENV10")
+
+PWT=$(echo "$OUTPUT10" | grep "^PROFILE_WEEK_TOKENS=" | cut -d= -f2)
+if [ -n "$PWT" ]; then
+    pass "PROFILE_WEEK_TOKENS present"
+else
+    fail "PROFILE_WEEK_TOKENS missing"
+fi
+assert_match "$PWT" "default:[0-9]+" "PROFILE_WEEK_TOKENS has default:N"
+assert_match "$PWT" "work:800" "PROFILE_WEEK_TOKENS work:800"
+
+# Aggregate WEEK_TOKENS must equal sum: 630+800=1430
+AGG10=$(echo "$OUTPUT10" | grep "^WEEK_TOKENS=" | cut -d= -f2)
+assert_eq "$AGG10" "1430" "WEEK_TOKENS aggregate = 1430"
+
+# ============================================================
+echo "=== Test 11: PROFILE_DAILY pipe-separated, 7 values per profile ==="
+# ============================================================
+ENV11=$(setup_env "test11")
+mkdir -p "$ENV11/.ccs/instances/work/projects/proj1"
+
+make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 100 50 0 0 "s1" \
+    > "$ENV11/.ccs/instances/work/projects/proj1/t.jsonl"
+
+OUTPUT11=$(run_script "$ENV11")
+
+PD=$(echo "$OUTPUT11" | grep "^PROFILE_DAILY=" | cut -d= -f2)
+if [ -n "$PD" ]; then
+    pass "PROFILE_DAILY present"
+else
+    fail "PROFILE_DAILY missing"
+fi
+
+# Verify pipe separator exists (at least 2 profiles = 1 pipe)
+assert_match "$PD" "[|]" "PROFILE_DAILY has pipe separator"
+
+# Each block should have 7 comma-separated values
+# Check work block: split on | then check count of commas in work part
+WORK_BLOCK=$(echo "$PD" | tr '|' '\n' | grep "^work:")
+WORK_VALS=$(echo "$WORK_BLOCK" | cut -d: -f2)
+COMMA_COUNT=$(echo "$WORK_VALS" | tr -cd ',' | wc -c)
+assert_eq "$COMMA_COUNT" "6" "PROFILE_DAILY work block has 7 values (6 commas)"
+
+# ============================================================
+echo "=== Test 12: PROFILE_WEEK_MODELS uses = not : for model/count ==="
+# ============================================================
+ENV12=$(setup_env "test12")
+mkdir -p "$ENV12/.ccs/instances/work/projects/proj1"
+
+make_jsonl_line "$TODAY" "claude-opus-4-20250514" 100 50 0 0 "s1" \
+    > "$ENV12/.ccs/instances/work/projects/proj1/t.jsonl"
+
+OUTPUT12=$(run_script "$ENV12")
+
+PWM=$(echo "$OUTPUT12" | grep "^PROFILE_WEEK_MODELS=" | cut -d= -f2-)
+if [ -n "$PWM" ]; then
+    pass "PROFILE_WEEK_MODELS present"
+else
+    fail "PROFILE_WEEK_MODELS missing"
+fi
+assert_match "$PWM" "opus=[0-9]+" "PROFILE_WEEK_MODELS uses = separator for model/count"
+
+# Also verify the aggregate WEEK_MODELS field uses = (not :)
+AGG_WM12=$(echo "$OUTPUT12" | sed -n 's/^WEEK_MODELS=//p')
+assert_match "$AGG_WM12" "opus=[0-9]+" "aggregate WEEK_MODELS also uses = separator"
 
 # ============================================================
 echo ""

--- a/translations.js
+++ b/translations.js
@@ -40,6 +40,10 @@ var strings = {
         { fr: "Intervalle de rafraîchissement" },
     "How often to fetch usage data (seconds)":
         { fr: "Fréquence de mise à jour des données (secondes)" },
+    "All":
+        { fr: "Tout" },
+    "Profile":
+        { fr: "Profil" },
 }
 
 function tr(key, lang) {

--- a/translations.js
+++ b/translations.js
@@ -44,6 +44,8 @@ var strings = {
         { fr: "Tout" },
     "Profile":
         { fr: "Profil" },
+    "total":
+        { fr: "total" },
 }
 
 function tr(key, lang) {


### PR DESCRIPTION
Adds native support for **[CCS (Claude Code Switcher)](https://github.com/kaitranntt/ccs)**, a tool that lets users manage multiple Claude accounts as named profiles (e.g., `work`, `home`, `personal`).

Without this PR, the widget only tracks the default `~/.claude/projects` directory. With CCS, users have additional profile directories under `~/.ccs/instances/<profile>/projects/`, and their usage was invisible to the widget.

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/091ab44b-945e-4eb4-9894-b60c8a01689b" width="300" alt="image 1"></td>
    <td><img src="https://github.com/user-attachments/assets/d60b2783-af20-4627-b656-5ce0345d9435" width="300" alt="image 2"></td>
  </tr>
</table>

## What changed

### `get-claude-usage`
- Discovers CCS profile instances from `~/.ccs/instances/`
- Runs token counting and usage/subscription fetching **in parallel** for each profile
- Aggregates totals across all profiles into the existing top-level output fields
- Emits new `PROFILE_*` output fields with per-profile breakdowns:
  - `PROFILES`: comma-separated list of active profile names
  - `PROFILE_WEEK_TOKENS`, `PROFILE_MONTH_TOKENS`: per-profile token counts
  - `PROFILE_TODAY_COST`, `PROFILE_WEEK_COST`, `PROFILE_MONTH_COST`: per-profile costs
  - `PROFILE_DAILY`, `PROFILE_DAILY_COSTS`: per-profile 7-day arrays (pipe-separated)
  - `PROFILE_WEEK_MODELS`: per-profile model breakdown
  - `PROFILE_SUBSCRIPTION`, `PROFILE_TIER`, `PROFILE_FIVE_HOUR_UTIL`, `PROFILE_SEVEN_DAY_UTIL`, etc.: per-profile rate-limit and subscription info read from each profile's own credentials file
- Sanitizes profile names (strips `,`, `|`, `:`) to prevent delimiter injection in output fields

> **⚠️ Minor breaking change:** `WEEK_MODELS` now uses `=` instead of `:` as the model/count separator (e.g. `claude-sonnet-4-5=1200`). This was necessary because model names themselves contain colons (e.g. `claude-opus-4-5-20251001`), making `:` ambiguous. External scripts parsing `WEEK_MODELS` will need to update their separator.

### `ClaudeCodeUsageWidget.qml`
- `profileListModel` populated from `PROFILES`; first entry is always `"all"`
- Profile selector UI: tab bar for ≤5 profiles, dropdown for >5
- `currentPd` reactive property: switches display between aggregate and per-profile data
- All display cards (`displayWeekTokens`, `displayMonthTokens`, `displayTodayCost`, `displayRateLimitTier`, `displaySubscriptionType`, etc.) derive from `currentPd`
- Chart shows per-profile daily **overlay bars** when a profile is selected
- `formatTier` / `formatSubscription` helpers handle new tier strings (`max`, `team`, `enterprise`)
- Tooltip "total" label is translated via `root.tr()`
- `PROFILE_EXTRA_USAGE` parsed as a proper boolean via `parseProfileBool` helper

### Tests
New coverage in `tests/test-get-claude-usage.sh`: profile discovery, `PROFILE_WEEK_TOKENS` format/values, `PROFILE_DAILY` pipe-separator, `PROFILE_WEEK_MODELS` `=` separator, plus upstream edge-case suite (week/month boundary, malformed JSONL, session deduplication, multi-project aggregation, cache parsing, cost math).

## How it works with CCS

CCS stores each profile under `~/.ccs/instances/<name>/`:
```
~/.ccs/instances/
  work/
    projects/          # scanned for JSONL usage logs
    .credentials.json  # used for rate-limit/subscription fetch
  personal/
    projects/
    .credentials.json
```

The script detects these directories automatically — no configuration needed. If CCS is not installed, only the default profile is shown and the widget behaves exactly as before. All existing output fields remain unchanged; the new `PROFILE_*` fields are purely additive.