### PR TITLE
Skip automatic bump when version is already updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_source_changes: ${{ steps.changes.outputs.has_source_changes }}
+      version_changed: ${{ steps.changes.outputs.version_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,10 +44,15 @@ jobs:
           else
             echo "has_source_changes=false" >> "$GITHUB_OUTPUT"
           fi
+          if git diff --quiet HEAD~1 HEAD -- plugin.json; then
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
   version-bump:
     needs: [shellcheck, tests, check-source-changes]
-    if: needs.check-source-changes.outputs.has_source_changes == 'true'
+    if: needs.check-source-changes.outputs.has_source_changes == 'true' && needs.check-source-changes.outputs.version_changed != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Avoid creating an extra patch-version PR when a merged change already updates `plugin.json`.

This keeps explicit release versions such as the `1.3.0` introduced by #32 instead of immediately proposing `1.3.1`.