### PR TITLE
Improve custom profile settings localization and spacing

### DIFF
--- a/ClaudeCodeUsageSettings.qml
+++ b/ClaudeCodeUsageSettings.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Common
+import qs.Services
 import qs.Widgets
 import qs.Modules.Plugins
 import "translations.js" as Tr
@@ -8,7 +9,7 @@ PluginSettings {
     id: root
     pluginId: "claudeCodeUsage"
 
-    property string lang: Qt.locale().name.split(/[_-]/)[0]
+    property string lang: (SessionData.locale || Qt.locale().name).split(/[_-]/)[0]
     function tr(key) {
         return Tr.tr(key, lang);
     }
@@ -55,26 +56,192 @@ PluginSettings {
         opacity: 0.3
     }
 
-    ListSettingWithInput {
-        settingKey: "customProfiles"
-        label: root.tr("Custom Profiles")
-        description: root.tr("Track extra Claude config directories. Point at a CLAUDE_CONFIG_DIR (the folder containing projects/). ~/.claude, Claude Code Switcher and claude-code-profiles are detected automatically.")
-        defaultValue: []
-        fields: [
-            {
-                id: "name",
-                label: root.tr("Name"),
-                placeholder: "work",
-                width: 130,
-                required: true
-            },
-            {
-                id: "path",
-                label: root.tr("Config directory"),
-                placeholder: "~/.ccp/data/work",
-                width: 230,
-                required: true
+    Column {
+        id: customProfilesSetting
+
+        width: parent.width
+        spacing: Theme.spacingM
+
+        property var items: []
+        property bool isLoading: false
+        readonly property real nameColumnWidth: Math.min(130, Math.max(100, width * 0.27))
+        readonly property real actionWidth: 92
+
+        Component.onCompleted: loadValue()
+
+        function loadValue() {
+            isLoading = true;
+            items = root.loadValue("customProfiles", []);
+            isLoading = false;
+        }
+
+        function saveItems(newItems) {
+            items = newItems;
+            if (!isLoading)
+                root.saveValue("customProfiles", items);
+        }
+
+        function addItem() {
+            var name = profileNameInput.text.trim();
+            var path = profilePathInput.text.trim();
+            if (!name || !path)
+                return;
+
+            saveItems(items.concat([{
+                name: name,
+                path: path
+            }]));
+            profileNameInput.text = "";
+            profilePathInput.text = "";
+            profileNameInput.forceActiveFocus();
+        }
+
+        function removeItem(index) {
+            var updatedItems = items.slice();
+            updatedItems.splice(index, 1);
+            saveItems(updatedItems);
+        }
+
+        StyledText {
+            text: root.tr("Custom Profiles")
+            font.pixelSize: Theme.fontSizeMedium
+            font.weight: Font.Medium
+            color: Theme.surfaceText
+        }
+
+        StyledText {
+            width: parent.width
+            text: root.tr("Track extra Claude config directories. Point at a CLAUDE_CONFIG_DIR (the folder containing projects/). ~/.claude, Claude Code Switcher and claude-code-profiles are detected automatically.")
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceVariantText
+            wrapMode: Text.WordWrap
+        }
+
+        Row {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            StyledText {
+                width: customProfilesSetting.nameColumnWidth
+                text: root.tr("Name")
+                font.pixelSize: Theme.fontSizeSmall
+                font.weight: Font.Medium
+                color: Theme.surfaceText
             }
-        ]
+
+            StyledText {
+                width: parent.width - customProfilesSetting.nameColumnWidth - customProfilesSetting.actionWidth - parent.spacing * 2
+                text: root.tr("Config directory")
+                font.pixelSize: Theme.fontSizeSmall
+                font.weight: Font.Medium
+                color: Theme.surfaceText
+            }
+
+            Item {
+                width: customProfilesSetting.actionWidth
+                height: 1
+            }
+        }
+
+        Row {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            DankTextField {
+                id: profileNameInput
+                width: customProfilesSetting.nameColumnWidth
+                placeholderText: "work"
+                Keys.onReturnPressed: customProfilesSetting.addItem()
+            }
+
+            DankTextField {
+                id: profilePathInput
+                width: parent.width - customProfilesSetting.nameColumnWidth - customProfilesSetting.actionWidth - parent.spacing * 2
+                placeholderText: "~/.ccp/data/work"
+                Keys.onReturnPressed: customProfilesSetting.addItem()
+            }
+
+            DankButton {
+                width: customProfilesSetting.actionWidth
+                height: 40
+                text: I18n.tr("Add")
+                onClicked: customProfilesSetting.addItem()
+            }
+        }
+
+        Column {
+            width: parent.width
+            spacing: Theme.spacingS
+
+            Repeater {
+                model: customProfilesSetting.items
+
+                StyledRect {
+                    required property int index
+                    required property var modelData
+
+                    width: parent.width
+                    height: 44
+                    radius: Theme.cornerRadius
+                    color: Theme.withAlpha(Theme.surfaceContainerHigh, Theme.popupTransparency)
+                    border.width: 0
+
+                    Row {
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingS
+                        spacing: Theme.spacingS
+
+                        StyledText {
+                            width: customProfilesSetting.nameColumnWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: modelData.name || ""
+                            color: Theme.surfaceText
+                            font.pixelSize: Theme.fontSizeMedium
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            width: parent.width - customProfilesSetting.nameColumnWidth - customProfilesSetting.actionWidth - parent.spacing * 2
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: modelData.path || ""
+                            color: Theme.surfaceVariantText
+                            font.pixelSize: Theme.fontSizeMedium
+                            elide: Text.ElideMiddle
+                        }
+
+                        Rectangle {
+                            width: customProfilesSetting.actionWidth
+                            height: 32
+                            anchors.verticalCenter: parent.verticalCenter
+                            color: removeArea.containsMouse ? Theme.errorHover : Theme.error
+                            radius: Theme.cornerRadius
+
+                            StyledText {
+                                anchors.centerIn: parent
+                                text: I18n.tr("Remove")
+                                color: Theme.onError
+                                font.pixelSize: Theme.fontSizeSmall
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: removeArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: customProfilesSetting.removeItem(index)
+                            }
+                        }
+                    }
+                }
+            }
+
+            StyledText {
+                text: I18n.tr("No items added yet")
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceVariantText
+                visible: customProfilesSetting.items.length === 0
+            }
+        }
     }
 }

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -11,7 +11,7 @@ PluginComponent {
     id: root
 
     // i18n
-    property string lang: Qt.locale().name.split(/[_-]/)[0]
+    property string lang: (SessionData.locale || Qt.locale().name).split(/[_-]/)[0]
     function tr(key) {
         return Tr.tr(key, lang);
     }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "claudeCodeUsage",
   "name": "Claude Code Usage",
   "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Nicolas Bellamy",
   "icon": "monitoring",
   "type": "widget",

--- a/translations.js
+++ b/translations.js
@@ -38,8 +38,8 @@ var strings = {
         { fr: "Surveillez l'utilisation de votre abonnement Claude Code. Les limites et le type d'abonnement sont détectés automatiquement via l'API Anthropic." },
     "Refresh Interval":
         { fr: "Intervalle de rafraîchissement" },
-    "How often to fetch usage data (seconds)":
-        { fr: "Fréquence de mise à jour des données (secondes)" },
+    "How often to fetch usage data (minutes)":
+        { fr: "Fréquence de mise à jour des données (minutes)" },
     "All":
         { fr: "Tout" },
     "Profile":


### PR DESCRIPTION
Fix the Custom Profiles settings so they follow the locale selected in DMS rather than only the system locale.

The profile form now uses an adaptive layout with wider Add/Remove actions, preventing translated labels such as `Ajouter` and `Supprimer` from looking cramped. This also adds the missing refresh-interval translation and bumps the patch version to `1.3.1`.