### PR TITLE
Add complete Spanish translations

### DIFF
--- a/ClaudeCodeUsageSettings.qml
+++ b/ClaudeCodeUsageSettings.qml
@@ -164,7 +164,7 @@ PluginSettings {
             DankButton {
                 width: customProfilesSetting.actionWidth
                 height: 40
-                text: I18n.tr("Add")
+                text: root.tr("Add")
                 onClicked: customProfilesSetting.addItem()
             }
         }
@@ -218,7 +218,7 @@ PluginSettings {
 
                             StyledText {
                                 anchors.centerIn: parent
-                                text: I18n.tr("Remove")
+                                text: root.tr("Remove")
                                 color: Theme.onError
                                 font.pixelSize: Theme.fontSizeSmall
                                 font.weight: Font.Medium
@@ -237,7 +237,7 @@ PluginSettings {
             }
 
             StyledText {
-                text: I18n.tr("No items added yet")
+                text: root.tr("No items added yet")
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.surfaceVariantText
                 visible: customProfilesSetting.items.length === 0

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -18,7 +18,12 @@ PluginComponent {
 
     // Calendar week labels: Monday to Sunday (fixed order)
     property int refreshEpoch: 0
-    property var dayLabels: lang === "fr" ? ["Lu", "Ma", "Me", "Je", "Ve", "Sa", "Di"] : ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+    readonly property var dayLabelsByLanguage: ({
+        en: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+        fr: ["Lu", "Ma", "Me", "Je", "Ve", "Sa", "Di"],
+        es: ["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"]
+    })
+    property var dayLabels: dayLabelsByLanguage[lang] || dayLabelsByLanguage.en
 
     // Settings
     property int refreshInterval: (pluginData.refreshInterval || 2) * 60000
@@ -348,19 +353,19 @@ PluginComponent {
         if (!tier || tier === "unknown")
             return "";
         if (tier.indexOf("max_20x") >= 0)
-            return "Max 20x";
+            return tr("Max") + " 20x";
         if (tier.indexOf("max_5x") >= 0)
-            return "Max 5x";
+            return tr("Max") + " 5x";
         if (tier.indexOf("max") >= 0)
-            return "Max";
+            return tr("Max");
         if (tier.indexOf("pro") >= 0)
-            return "Pro";
+            return tr("Pro");
         if (tier.indexOf("free") >= 0)
-            return "Free";
+            return tr("Free");
         if (tier.indexOf("team") >= 0)
-            return "Team";
+            return tr("Team");
         if (tier.indexOf("enterprise") >= 0)
-            return "Enterprise";
+            return tr("Enterprise");
         return tier.replace(/_/g, " ").replace(/\b\w/g, function (c) {
             return c.toUpperCase();
         });

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "claudeCodeUsage",
   "name": "Claude Code Usage",
   "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "Nicolas Bellamy",
   "icon": "monitoring",
   "type": "widget",

--- a/tests/test-translations.sh
+++ b/tests/test-translations.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Checks that every plugin translation key has complete French and Spanish entries.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "SKIP: Node.js not available, skipping translation tests"
+    exit 0
+fi
+
+node - "$SCRIPT_DIR" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const root = process.argv[2];
+const catalogPath = path.join(root, "translations.js");
+const catalogSource = fs.readFileSync(catalogPath, "utf8").replace(/^\.pragma library\s*/, "");
+const sandbox = {};
+vm.createContext(sandbox);
+vm.runInContext(catalogSource, sandbox, { filename: catalogPath });
+
+const keys = new Set();
+for (const filename of ["ClaudeCodeUsageWidget.qml", "ClaudeCodeUsageSettings.qml"]) {
+    const source = fs.readFileSync(path.join(root, filename), "utf8");
+    const pattern = /(?:root\.)?tr\("([^"]+)"\)/g;
+    let match;
+    while ((match = pattern.exec(source)) !== null)
+        keys.add(match[1]);
+}
+
+let failed = false;
+for (const key of [...keys].sort()) {
+    const entry = sandbox.strings[key];
+    for (const language of ["fr", "es"]) {
+        if (!entry || typeof entry[language] !== "string" || entry[language].trim() === "") {
+            console.error(`FAIL: missing ${language} translation for "${key}"`);
+            failed = true;
+        }
+    }
+}
+
+for (const [key, expected] of [
+    ["Custom Profiles", "Perfiles personalizados"],
+    ["No items added yet", "Todavía no se ha añadido ningún elemento"],
+    ["msgs", "messages"]
+]) {
+    const language = key === "msgs" ? "fr" : "es";
+    if (sandbox.tr(key, language) !== expected) {
+        console.error(`FAIL: unexpected ${language} translation for "${key}"`);
+        failed = true;
+    }
+}
+
+const widget = fs.readFileSync(path.join(root, "ClaudeCodeUsageWidget.qml"), "utf8");
+if (!/es:\s*\["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"\]/.test(widget)) {
+    console.error("FAIL: Spanish weekday labels are missing");
+    failed = true;
+}
+
+if (failed)
+    process.exit(1);
+
+console.log(`PASS: ${keys.size} UI keys have complete French and Spanish translations`);
+console.log("PASS: Spanish weekday labels are present");
+NODE

--- a/translations.js
+++ b/translations.js
@@ -2,71 +2,96 @@
 
 var strings = {
     "Claude Code Usage":
-        { fr: "Utilisation Claude Code" },
+        { fr: "Utilisation Claude Code", es: "Uso de Claude Code" },
     "Subscription":
-        { fr: "Abonnement" },
+        { fr: "Abonnement", es: "Suscripción" },
     "5h Rate Window":
-        { fr: "Fenêtre 5h" },
+        { fr: "Fenêtre de 5 h", es: "Ventana de 5 h" },
     "used":
-        { fr: "utilisé" },
+        { fr: "utilisé", es: "usado" },
     "Resets in":
-        { fr: "Réinitialise dans" },
+        { fr: "Réinitialisation dans", es: "Restablecimiento en" },
     "Resetting...":
-        { fr: "Réinitialisation..." },
+        { fr: "Réinitialisation...", es: "Restableciendo..." },
     "7-Day Usage":
-        { fr: "Utilisation 7 jours" },
+        { fr: "Utilisation sur 7 jours", es: "Uso durante 7 días" },
     "sessions":
-        { fr: "sessions" },
+        { fr: "sessions", es: "sesiones" },
     "msgs":
-        { fr: "msgs" },
+        { fr: "messages", es: "mensajes" },
     "Daily Activity":
-        { fr: "Activité quotidienne" },
+        { fr: "Activité quotidienne", es: "Actividad diaria" },
     "Token Consumption":
-        { fr: "Consommation de tokens" },
+        { fr: "Consommation de tokens", es: "Consumo de tokens" },
     "Today":
-        { fr: "Aujourd'hui" },
+        { fr: "Aujourd'hui", es: "Hoy" },
     "Week":
-        { fr: "Semaine" },
+        { fr: "Semaine", es: "Semana" },
     "Month":
-        { fr: "Mois" },
+        { fr: "Mois", es: "Mes" },
     "Models This Week":
-        { fr: "Modèles cette semaine" },
+        { fr: "Modèles cette semaine", es: "Modelos esta semana" },
     "Since":
-        { fr: "Depuis" },
+        { fr: "Depuis", es: "Desde" },
+    "Max":
+        { fr: "Max", es: "Max" },
+    "Pro":
+        { fr: "Pro", es: "Pro" },
+    "Free":
+        { fr: "Gratuit", es: "Gratis" },
+    "Team":
+        { fr: "Équipe", es: "Equipo" },
+    "Enterprise":
+        { fr: "Entreprise", es: "Empresa" },
     // Settings
     "Monitor your Claude Code subscription usage. Rate limits and subscription tier are detected automatically via the Anthropic API.":
-        { fr: "Surveillez l'utilisation de votre abonnement Claude Code. Les limites et le type d'abonnement sont détectés automatiquement via l'API Anthropic." },
+        {
+            fr: "Surveillez l'utilisation de votre abonnement Claude Code. Les limites d'utilisation et le type d'abonnement sont détectés automatiquement via l'API Anthropic.",
+            es: "Supervisa el uso de tu suscripción a Claude Code. Los límites de uso y el tipo de suscripción se detectan automáticamente mediante la API de Anthropic."
+        },
     "Refresh Interval":
-        { fr: "Intervalle de rafraîchissement" },
+        { fr: "Intervalle de rafraîchissement", es: "Intervalo de actualización" },
     "How often to fetch usage data (minutes)":
-        { fr: "Fréquence de mise à jour des données (minutes)" },
+        { fr: "Fréquence de mise à jour des données (minutes)", es: "Frecuencia de actualización de los datos (minutos)" },
     "All":
-        { fr: "Tout" },
+        { fr: "Tout", es: "Todos" },
     "Profile":
-        { fr: "Profil" },
+        { fr: "Profil", es: "Perfil" },
     "total":
-        { fr: "total" },
+        { fr: "total", es: "total" },
     // Pacing
     "over pace":
-        { fr: "au-dessus du rythme" },
+        { fr: "au-dessus du rythme", es: "por encima del ritmo" },
     "under pace":
-        { fr: "en dessous du rythme" },
+        { fr: "en dessous du rythme", es: "por debajo del ritmo" },
     "On pace":
-        { fr: "Dans les temps" },
+        { fr: "Dans les temps", es: "Al ritmo previsto" },
     "Over quota":
-        { fr: "Quota dépassé" },
+        { fr: "Quota dépassé", es: "Cuota superada" },
     "Show pacing":
-        { fr: "Afficher le rythme" },
+        { fr: "Afficher le rythme", es: "Mostrar el ritmo de consumo" },
     "Show whether usage is ahead of or behind the time window":
-        { fr: "Indique si l'utilisation est en avance ou en retard sur la fenêtre de temps" },
+        {
+            fr: "Indique si l'utilisation est en avance ou en retard sur la fenêtre de temps",
+            es: "Indica si el consumo está adelantado o retrasado respecto a la ventana de tiempo"
+        },
     "Custom Profiles":
-        { fr: "Profils personnalisés" },
+        { fr: "Profils personnalisés", es: "Perfiles personalizados" },
     "Name":
-        { fr: "Nom" },
+        { fr: "Nom", es: "Nombre" },
     "Config directory":
-        { fr: "Dossier de configuration" },
+        { fr: "Dossier de configuration", es: "Directorio de configuración" },
     "Track extra Claude config directories. Point at a CLAUDE_CONFIG_DIR (the folder containing projects/). ~/.claude, Claude Code Switcher and claude-code-profiles are detected automatically.":
-        { fr: "Suivre d'autres dossiers de configuration Claude. Indiquez un CLAUDE_CONFIG_DIR (le dossier contenant projects/). ~/.claude, Claude Code Switcher et claude-code-profiles sont détectés automatiquement." },
+        {
+            fr: "Suivez d'autres dossiers de configuration Claude. Indiquez un CLAUDE_CONFIG_DIR (le dossier contenant projects/). ~/.claude, Claude Code Switcher et claude-code-profiles sont détectés automatiquement.",
+            es: "Haz seguimiento de otros directorios de configuración de Claude. Indica un CLAUDE_CONFIG_DIR (la carpeta que contiene projects/). ~/.claude, Claude Code Switcher y claude-code-profiles se detectan automáticamente."
+        },
+    "Add":
+        { fr: "Ajouter", es: "Añadir" },
+    "Remove":
+        { fr: "Supprimer", es: "Eliminar" },
+    "No items added yet":
+        { fr: "Aucun élément ajouté pour le moment", es: "Todavía no se ha añadido ningún elemento" },
 }
 
 function tr(key, lang) {


### PR DESCRIPTION
Audit every user-facing plugin string and provide complete French and Spanish catalogs.

This also translates subscription tiers and action labels, adds Spanish weekday abbreviations, improves a few French phrasings, and introduces a regression test ensuring every `tr()` key remains available in both languages.

Version: `1.3.2`.