### PR TITLE
Harden profile caching and automated bump CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   shellcheck:
@@ -55,6 +56,7 @@ jobs:
     if: needs.check-source-changes.outputs.has_source_changes == 'true' && needs.check-source-changes.outputs.version_changed != 'true'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -87,3 +89,7 @@ jobs:
           gh pr create \
             --title "Bump version to ${new_version}" \
             --body "Automated patch version bump: \`${current}\` → \`${new_version}\`"
+
+          # Events created by GITHUB_TOKEN do not trigger other workflow runs.
+          # Dispatch CI explicitly so required checks attach to the bump commit.
+          gh workflow run ci.yml --ref "$branch"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -250,9 +250,12 @@ fetch_profile_usage() {
 
     # Check cache freshness
     local api_resp="{}"
-    local use_cache=false
+    local use_cache=false cache_matches=false
     if [ -f "$cache_file" ]; then
-        local cache_ts now_ts age
+        local cache_identity cache_ts now_ts age
+        cache_identity=$(jq -r '.identity // ""' "$cache_file" 2>/dev/null | head -1)
+        [ "$cache_identity" = "$creds_file" ] && cache_matches=true
+
         # Take only the first line and validate it's a plain integer. A corrupt
         # cache (e.g. from interleaved concurrent writes) makes jq emit the first
         # object's value AND then error, which the `|| echo 0` turns into a
@@ -261,7 +264,7 @@ fetch_profile_usage() {
         [[ "$cache_ts" =~ ^[0-9]+$ ]] || cache_ts=0
         now_ts=$(date +%s)
         age=$(( now_ts - cache_ts ))
-        [ "$age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
+        [ "$cache_matches" = true ] && [ "$age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
     fi
 
     if [ "$use_cache" = true ]; then
@@ -283,12 +286,13 @@ fetch_profile_usage() {
                 # same cache file, and a plain `> "$cache_file"` interleaves their
                 # output into corrupt JSON. Write to a per-PID temp then rename.
                 local cache_tmp="${cache_file}.$$.tmp"
-                if jq -n --argjson data "$api_resp" '{cached_at: (now | floor), data: $data}' > "$cache_tmp" 2>/dev/null; then
+                if jq -n --arg identity "$creds_file" --argjson data "$api_resp" \
+                    '{cached_at: (now | floor), identity: $identity, data: $data}' > "$cache_tmp" 2>/dev/null; then
                     mv -f "$cache_tmp" "$cache_file" 2>/dev/null || rm -f "$cache_tmp"
                 else
                     rm -f "$cache_tmp"
                 fi
-            elif [ -f "$cache_file" ]; then
+            elif [ "$cache_matches" = true ]; then
                 api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
             fi
         fi

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "claudeCodeUsage",
   "name": "Claude Code Usage",
   "description": "Monitor your Claude Code subscription usage with token tracking, estimated API costs, rate limits, and daily activity charts",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": "Nicolas Bellamy",
   "icon": "monitoring",
   "type": "widget",

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -469,6 +469,7 @@ NOW_TS=$(date +%s)
 cat > "$ENV18/.claude/usage-cache.json" << CACHEEOF
 {
     "cached_at": $NOW_TS,
+    "identity": "$ENV18/.claude/.credentials.json",
     "data": {
         "five_hour": {"utilization": 42, "resets_at": "2099-01-01T00:00:00Z"},
         "seven_day": {"utilization": 15, "resets_at": "2099-01-07T00:00:00Z"},
@@ -484,6 +485,14 @@ SEVEN18=$(echo "$OUTPUT18" | grep "^SEVEN_DAY_UTIL=" | cut -d= -f2)
 assert_eq "$SEVEN18" "15" "Fresh cache: SEVEN_DAY_UTIL from cache"
 EXTRA18=$(echo "$OUTPUT18" | grep "^EXTRA_USAGE_ENABLED=" | cut -d= -f2)
 assert_eq "$EXTRA18" "true" "Fresh cache: EXTRA_USAGE_ENABLED from cache"
+
+# A fresh cache created for another config directory must not leak usage data
+sed "s|$ENV18/.claude/.credentials.json|$ENV18/old-profile/.credentials.json|" \
+    "$ENV18/.claude/usage-cache.json" > "$ENV18/.claude/usage-cache-other.json"
+mv "$ENV18/.claude/usage-cache-other.json" "$ENV18/.claude/usage-cache.json"
+OUTPUT18B=$(run_script "$ENV18")
+FIVE18B=$(echo "$OUTPUT18B" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)
+assert_eq "$FIVE18B" "0" "Fresh cache from another profile is ignored"
 
 # ============================================================
 echo "=== Test 19: Stats cache parsing ==="

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -42,12 +42,31 @@ function progressColor(pct) {
     return "primary"
 }
 
+var testLang = "en"
+var tierTranslations = {
+    Free: { fr: "Gratuit", es: "Gratis" },
+    Team: { fr: "Équipe", es: "Equipo" },
+    Enterprise: { fr: "Entreprise", es: "Empresa" }
+}
+
+function tr(key) {
+    return tierTranslations[key] && tierTranslations[key][testLang]
+        ? tierTranslations[key][testLang]
+        : key
+}
+
 function formatTier(tier) {
-    if (tier.indexOf("max_20x") >= 0) return "Max 20x"
-    if (tier.indexOf("max_5x") >= 0) return "Max 5x"
-    if (tier.indexOf("pro") >= 0) return "Pro"
-    if (tier.indexOf("free") >= 0) return "Free"
-    return tier
+    if (!tier || tier === "unknown") return ""
+    if (tier.indexOf("max_20x") >= 0) return tr("Max") + " 20x"
+    if (tier.indexOf("max_5x") >= 0) return tr("Max") + " 5x"
+    if (tier.indexOf("max") >= 0) return tr("Max")
+    if (tier.indexOf("pro") >= 0) return tr("Pro")
+    if (tier.indexOf("free") >= 0) return tr("Free")
+    if (tier.indexOf("team") >= 0) return tr("Team")
+    if (tier.indexOf("enterprise") >= 0) return tr("Enterprise")
+    return tier.replace(/_/g, " ").replace(/\b\w/g, function (c) {
+        return c.toUpperCase()
+    })
 }
 
 function formatCost(usd, lang, usdEurRate) {
@@ -202,9 +221,9 @@ echo "=== Test 4: formatTier ==="
 # ============================================================
 
 test_format_tier() {
-    local input="$1" expected="$2" label="$3"
+    local input="$1" lang="$2" expected="$3" label="$4"
     local result
-    result=$(run_js "${JS_HARNESS} console.log(formatTier('$input'))")
+    result=$(run_js "${JS_HARNESS} testLang='$lang'; console.log(formatTier('$input'))")
     if [ "$result" = "$expected" ]; then
         pass "$label"
     else
@@ -212,12 +231,14 @@ test_format_tier() {
     fi
 }
 
-test_format_tier "t3_max_20x_something" "Max 20x" "formatTier max_20x"
-test_format_tier "t2_max_5x_something" "Max 5x" "formatTier max_5x"
-test_format_tier "t1_pro_something" "Pro" "formatTier pro"
-test_format_tier "free_tier" "Free" "formatTier free"
-test_format_tier "unknown" "unknown" "formatTier unknown passthrough"
-test_format_tier "custom_plan" "custom_plan" "formatTier unrecognised passthrough"
+test_format_tier "t3_max_20x_something" "en" "Max 20x" "formatTier max_20x"
+test_format_tier "t2_max_5x_something" "en" "Max 5x" "formatTier max_5x"
+test_format_tier "t1_pro_something" "en" "Pro" "formatTier pro"
+test_format_tier "free_tier" "fr" "Gratuit" "formatTier free in French"
+test_format_tier "team_tier" "es" "Equipo" "formatTier team in Spanish"
+test_format_tier "enterprise_tier" "fr" "Entreprise" "formatTier enterprise in French"
+test_format_tier "unknown" "en" "" "formatTier hides unknown"
+test_format_tier "custom_plan" "en" "Custom Plan" "formatTier formats unrecognised tiers"
 
 # ============================================================
 echo "=== Test 5: formatCost ==="


### PR DESCRIPTION
Follow-up from a code review of the multi-profile and localization changes.

- bind usage caches to their credentials path so a reused profile name cannot briefly display another account utilization;
- explicitly dispatch CI for version-bump PRs created by `GITHUB_TOKEN`, allowing required checks to run;
- add cache-identity and localized-tier regression coverage;
- bump the patch version to `1.3.3`.