### PR TITLE
fix: bound the usage script with a timeout so the widget cannot freeze

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -697,7 +697,11 @@ PluginComponent {
 
     Process {
         id: usageProcess
-        command: ["bash", root.scriptPath].concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
+        // Wrapped in `timeout` as a watchdog. The refresh timer below skips a tick
+        // while `running` is true, so a single run that never exits (a hung
+        // `claude --version`, a stalled curl/find) freezes the widget on stale
+        // values until the plugin is reloaded. Killing the run lets onExited fire.
+        command: ["timeout", "120", "bash", root.scriptPath].concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
         running: false
 
         stdout: SplitParser {


### PR DESCRIPTION
## Problem

The widget can stop refreshing and keep showing old numbers until the plugin is reloaded. I hit it today: DMS started `07:34`, the plugin ran once, then nothing for over two hours. The popout showed `0% used` and `Resets in Resetting...` while the account was really at 29%.

The refresh timer skips a tick while a run is still going:

```qml
onTriggered: {
    if (!usageProcess.running)
        usageProcess.running = true;
}
```

Nothing bounds a run. `get-claude-usage:14` calls `claude --version` with no timeout, and the `find | jq | awk` pipeline has none either. So one run that never exits ⇒ `running` stays `true` ⇒ `onExited` never fires ⇒ the widget is frozen for good.

Being honest about the evidence: I could not catch the stuck process in the act, the plugin reload had already reaped it. But no other path keeps the data stale that long, and the run is unbounded today either way.

## Fix

Wrap the command in `timeout 120`. A stuck run gets killed, `onExited` fires, `running` goes back to false, next tick refreshes.

`timeout` is coreutils, so no real new dependency. I did not add it to `requires` in `plugin.json` - tell me if you prefer it there.

## Testing

- `for t in tests/test-*.sh; do bash "$t"; done` - all pass
- Running with the patch on Arch / niri / DMS `1.5.0-203`, refresh steady every 2 min for the last 90 minutes

## Separate observation, not in this PR

Refresh interval minimum is 2 min and `USAGE_CACHE_TTL` is also 120s, so roughly every second run serves the cache and the API numbers can be ~4 min old. Not a bug, but a small mismatch. Happy to open a separate issue.
