### PR TITLE
fix: lower USAGE_CACHE_TTL below the minimum refresh interval

### DIFF
--- a/get-claude-usage
+++ b/get-claude-usage
@@ -8,7 +8,7 @@ CLAUDE_DIR="${HOME}/.claude"
 STATS_CACHE="${CLAUDE_DIR}/stats-cache.json"
 PRICING_CACHE="${CLAUDE_DIR}/pricing-cache.json"
 USAGE_CACHE="${CLAUDE_DIR}/usage-cache.json"
-USAGE_CACHE_TTL=120  # seconds
+USAGE_CACHE_TTL=90  # seconds, below the 2 min minimum refresh interval
 LITELLM_URL="https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
 
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")


### PR DESCRIPTION
## Problem

`USAGE_CACHE_TTL=120` in `get-claude-usage:11` is exactly the minimum refresh interval - `ClaudeCodeUsageSettings.qml:38` sets `minimum: 2` minutes. Every scheduled run lands right on that boundary, so roughly every second run reads the cache instead of calling the API. Set the interval to 2 min and the rate limit numbers can still be about 4 min old.

Measured here, the cache file was rewritten every 4 minutes, not every 2:

```
10:02:40  10:06:40  10:10:40  10:14:40  10:18:40  10:22:40
```

## Fix

`USAGE_CACHE_TTL=90`. Below the 2 min minimum, so a scheduled run always refetches. The cache still does its real job - swallowing the burst of runs from a plugin reload or a Custom Profiles edit.

90 is a fixed number that only holds because the slider floor is 2 min. If that floor ever drops, the mismatch comes back. Passing the interval into the script as an argument would be the general fix, but that felt like more machinery than this deserves. Say if you prefer it.

## Testing

- `for t in tests/test-*.sh; do bash "$t"; done` - all pass. Test 18 seeds `cached_at` at now, so the fresh-cache path is still covered.
- Running on Arch / niri / DMS `1.5.0-203`.
