### PR TITLE
fix: stop per-model token totals wrapping negative

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -1511,8 +1511,10 @@ PluginComponent {
 
                                     // When model is a ListModel, role names are direct properties.
                                     // When model is a JS array, values are accessed via modelData.
+                                    // `real`, not `int`: a weekly per-model total passes the signed
+                                    // 32-bit range (2.1B tokens), and `int` wraps it negative.
                                     property string _modelName: modelListData === modelRepeater.model ? modelName : (modelData ? modelData.modelName : "")
-                                    property int _modelTokens: modelListData === modelRepeater.model ? modelTokens : (modelData ? (modelData.modelTokens || 0) : 0)
+                                    property real _modelTokens: modelListData === modelRepeater.model ? modelTokens : (modelData ? (modelData.modelTokens || 0) : 0)
 
                                     Row {
                                         width: parent.width

--- a/tests/test-qml-syntax.sh
+++ b/tests/test-qml-syntax.sh
@@ -47,6 +47,19 @@ for f in $QML_FILES; do
     fi
 done
 
+echo "=== Test 4: Token counts are not declared as 32-bit int ==="
+for f in $QML_FILES; do
+    name=$(basename "$f")
+    # QML `int` is signed 32-bit, so it wraps negative past 2147483647. A weekly
+    # per-model token total passes that, so token properties must be `real`.
+    if grep -qE '^[[:space:]]*property[[:space:]]+int[[:space:]]+[A-Za-z_]*[Tt]okens' "$f"; then
+        grep -nE '^[[:space:]]*property[[:space:]]+int[[:space:]]+[A-Za-z_]*[Tt]okens' "$f" >&2
+        fail "$name declares a token count as int (wraps negative past 2.1B)"
+    else
+        pass "$name declares token counts as real"
+    fi
+done
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
`_modelTokens` was declared `property int`, and QML `int` is signed 32-bit. A weekly per-model total passes `2147483647` on heavy use, so it wraps: an Opus week of `3163688732` tokens renders as `-1131278564` in the Models This Week list, and the bar next to it collapses to zero width because the ratio goes negative.

Fix: declare it `real`, like `weekTokens` and `monthTokens` already are.

Also added a grep guard in `tests/test-qml-syntax.sh` so a token count declared `int` fails the suite.

**Verification**

`tests/test-qml-syntax.sh` - 6 passed, 0 failed. The guard fails as expected when the declaration is reverted to `int`.
