### PR TITLE
feat: count the other clients spending this subscription

### DIFF
--- a/ClaudeCodeUsageSettings.qml
+++ b/ClaudeCodeUsageSettings.qml
@@ -49,6 +49,13 @@ PluginSettings {
         defaultValue: true
     }
 
+    ToggleSetting {
+        settingKey: "countBridged"
+        label: root.tr("Count other clients")
+        description: root.tr("Also count agents that reach this subscription through a bridge, not only Claude Code")
+        defaultValue: true
+    }
+
     Rectangle {
         width: parent.width
         height: 1

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -39,6 +39,11 @@ PluginComponent {
     property real sevenDayUtil: 0
     property string sevenDayReset: ""
     property bool extraUsageEnabled: false
+    // How much the rate limit numbers above can be trusted. usageError is empty
+    // when the last fetch succeeded; otherwise usageAge is how old the numbers
+    // being shown are, in seconds (0 = there is no data at all).
+    property int usageAge: 0
+    property string usageError: ""
 
     // Weekly state
     property int weekMessages: 0
@@ -101,6 +106,23 @@ PluginComponent {
     property string displayFiveHourReset: currentPd && currentPd.fiveHourReset !== undefined ? currentPd.fiveHourReset : fiveHourReset
     property real displaySevenDayUtil: currentPd && currentPd.sevenDayUtil !== undefined ? currentPd.sevenDayUtil : sevenDayUtil
     property string displaySevenDayReset: currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
+    property int displayUsageAge: currentPd && currentPd.usageAge !== undefined ? currentPd.usageAge : usageAge
+    property string displayUsageError: currentPd && currentPd.usageError !== undefined ? currentPd.usageError : usageError
+
+    // One line telling the user the rate limit numbers are not live, and why.
+    // Empty while the fetch is healthy, which is the normal case.
+    property string usageWarning: {
+        if (!displayUsageError)
+            return "";
+        var reason = usageErrorLabel(displayUsageError);
+        if (displayUsageAge <= 0)
+            return reason;
+        return formatAge(displayUsageAge) + " " + tr("old") + " · " + reason;
+    }
+    // Suffix for every rate limit percentage that came from a failed fetch, so a
+    // number is never presented as live. The reason itself is printed once, in
+    // the 5h card, rather than repeated under each ring.
+    property string staleMark: usageWarning === "" ? "" : "?"
     property real displayWeekTokens: currentPd && currentPd.weekTokens !== undefined ? currentPd.weekTokens : weekTokens
     property int displayWeekMessages: currentPd && currentPd.weekMessages !== undefined ? currentPd.weekMessages : weekMessages
     property int displayWeekSessions: currentPd && currentPd.weekSessions !== undefined ? currentPd.weekSessions : weekSessions
@@ -237,6 +259,38 @@ PluginComponent {
         if (n >= 1000)
             return (n / 1000).toFixed(1) + "K";
         return Math.round(n).toString();
+    }
+
+    // Seconds → "45m" / "3h 37m" / "2d 4h". Used for how old stale numbers are.
+    function formatAge(seconds) {
+        if (!(seconds > 0))
+            return "0m";
+        var mins = Math.floor(seconds / 60);
+        if (mins < 60)
+            return mins + "m";
+        var hours = Math.floor(mins / 60);
+        if (hours < 24)
+            return hours + "h " + (mins % 60) + "m";
+        return Math.floor(hours / 24) + "d " + (hours % 24) + "h";
+    }
+
+    function usageErrorLabel(code) {
+        switch (code) {
+        case "token_expired":
+            return tr("Claude Code login expired");
+        case "rate_limited":
+            return tr("API rate limited");
+        case "unauthorized":
+            return tr("Not authorized");
+        case "offline":
+            return tr("No connection");
+        case "no_credentials":
+            return tr("Not signed in");
+        case "bad_response":
+            return tr("Unexpected API response");
+        default:
+            return code;
+        }
     }
 
     function shortModelName(name) {
@@ -474,6 +528,12 @@ PluginComponent {
         case "EXTRA_USAGE_ENABLED":
             extraUsageEnabled = (val === "true");
             break;
+        case "USAGE_AGE":
+            usageAge = parseInt(val) || 0;
+            break;
+        case "USAGE_ERROR":
+            usageError = val;
+            break;
         case "WEEK_MESSAGES":
             weekMessages = parseInt(val) || 0;
             break;
@@ -600,6 +660,12 @@ PluginComponent {
             break;
         case "PROFILE_EXTRA_USAGE":
             profileData = parseProfileBool(val, "extraUsageEnabled");
+            break;
+        case "PROFILE_USAGE_AGE":
+            profileData = parseProfileSimple(val, "usageAge", false);
+            break;
+        case "PROFILE_USAGE_ERROR":
+            profileData = parseProfileString(val, "usageError");
             break;
         case "PROFILE_DAILY":
             {
@@ -739,6 +805,9 @@ PluginComponent {
     horizontalBarPill: Component {
         Row {
             spacing: Theme.spacingXS
+            // Dimmed with a "?" suffix while the numbers are not live, so the bar
+            // never states a percentage it cannot back up. Details in the popout.
+            opacity: root.usageError !== "" ? 0.6 : 1
 
             Canvas {
                 id: hRing
@@ -775,9 +844,9 @@ PluginComponent {
             }
 
             StyledText {
-                text: Math.round(root.fiveHourUtil) + "%" + (root.pillOverPace ? " ↑" : "")
+                text: Math.round(root.fiveHourUtil) + "%" + (root.usageError !== "" ? "?" : (root.pillOverPace ? " ↑" : ""))
                 font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-                color: root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
+                color: root.usageError === "" && root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
                 anchors.verticalCenter: parent.verticalCenter
             }
         }
@@ -786,6 +855,7 @@ PluginComponent {
     verticalBarPill: Component {
         Column {
             spacing: Theme.spacingXS || 4
+            opacity: root.usageError !== "" ? 0.6 : 1
 
             Canvas {
                 id: vRing
@@ -822,9 +892,9 @@ PluginComponent {
             }
 
             StyledText {
-                text: Math.round(root.fiveHourUtil) + "%" + (root.pillOverPace ? " ↑" : "")
+                text: Math.round(root.fiveHourUtil) + "%" + (root.usageError !== "" ? "?" : (root.pillOverPace ? " ↑" : ""))
                 font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
-                color: root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
+                color: root.usageError === "" && root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
                 anchors.horizontalCenter: parent.horizontalCenter
             }
         }
@@ -1048,7 +1118,7 @@ PluginComponent {
 
                             StyledText {
                                 anchors.centerIn: parent
-                                text: Math.round(root.displayFiveHourUtil) + "%"
+                                text: Math.round(root.displayFiveHourUtil) + "%" + root.staleMark
                                 font.pixelSize: Theme.fontSizeXLarge
                                 font.weight: Font.DemiBold
                                 color: Theme.surfaceText
@@ -1070,7 +1140,7 @@ PluginComponent {
                             }
                             StyledText {
                                 width: parent.width
-                                text: Math.round(root.displayFiveHourUtil) + "% " + root.tr("used")
+                                text: Math.round(root.displayFiveHourUtil) + "%" + root.staleMark + " " + root.tr("used")
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: root.progressColor(root.displayFiveHourUtil)
                                 wrapMode: Text.WordWrap
@@ -1078,7 +1148,7 @@ PluginComponent {
                             StyledText {
                                 width: parent.width
                                 text: root.paceLabel(root.fiveHourPace)
-                                visible: root.showPacing && text !== ""
+                                visible: root.showPacing && root.usageWarning === "" && text !== ""
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: root.paceColor(root.fiveHourPace.status)
                                 wrapMode: Text.WordWrap
@@ -1088,7 +1158,18 @@ PluginComponent {
                                 text: root.displayFiveHourCountdown ? root.tr("Resets in") + " " + root.displayFiveHourCountdown : ""
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.surfaceVariantText
-                                visible: root.displayFiveHourCountdown !== ""
+                                // Hidden while the numbers are not live: the reset time comes
+                                // from the same stale response, so it counts down to an instant
+                                // that has already passed and reads "Resetting..." forever.
+                                visible: root.usageWarning === "" && root.displayFiveHourCountdown !== ""
+                                wrapMode: Text.WordWrap
+                            }
+                            StyledText {
+                                width: parent.width
+                                text: root.usageWarning
+                                visible: root.usageWarning !== ""
+                                font.pixelSize: Theme.fontSizeMedium
+                                color: Theme.error
                                 wrapMode: Text.WordWrap
                             }
                         }
@@ -1145,7 +1226,7 @@ PluginComponent {
 
                             StyledText {
                                 anchors.centerIn: parent
-                                text: Math.round(root.displaySevenDayUtil) + "%"
+                                text: Math.round(root.displaySevenDayUtil) + "%" + root.staleMark
                                 font.pixelSize: 14
                                 font.weight: Font.DemiBold
                                 color: Theme.surfaceText
@@ -1159,7 +1240,7 @@ PluginComponent {
 
                             StyledText {
                                 width: parent.width
-                                text: root.tr("7-Day Usage") + " · " + Math.round(root.displaySevenDayUtil) + "%"
+                                text: root.tr("7-Day Usage") + " · " + Math.round(root.displaySevenDayUtil) + "%" + root.staleMark
                                 font.pixelSize: Theme.fontSizeMedium
                                 font.weight: Font.Medium
                                 color: Theme.surfaceText
@@ -1168,7 +1249,7 @@ PluginComponent {
                             StyledText {
                                 width: parent.width
                                 text: root.paceLabel(root.sevenDayPace)
-                                visible: root.showPacing && text !== ""
+                                visible: root.showPacing && root.usageWarning === "" && text !== ""
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: root.paceColor(root.sevenDayPace.status)
                                 wrapMode: Text.WordWrap
@@ -1193,7 +1274,7 @@ PluginComponent {
                                 text: root.displaySevenDayCountdown ? root.tr("Resets in") + " " + root.displaySevenDayCountdown : ""
                                 font.pixelSize: Theme.fontSizeSmall
                                 color: Theme.surfaceVariantText
-                                visible: root.displaySevenDayCountdown !== ""
+                                visible: root.usageWarning === "" && root.displaySevenDayCountdown !== ""
                                 wrapMode: Text.WordWrap
                             }
                         }

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -45,6 +45,11 @@ PluginComponent {
     // Settings
     property int refreshInterval: (pluginData.refreshInterval || 2) * 60000
     property bool showPacing: pluginData.showPacing !== false
+    // Count the transcripts of other clients on this subscription (a harness
+    // reaching Anthropic through a bridge like cliproxyapi). On by default: their
+    // tokens are already inside the rate limit rings, so leaving them out is what
+    // looks broken - "today 0" under a ring that says 16% used.
+    property bool countBridged: pluginData.countBridged !== false
     property var customProfiles: pluginData.customProfiles || []
     // A refresh asked for while one is already in flight. onExited starts it,
     // so the request is queued rather than dropped.
@@ -920,7 +925,7 @@ PluginComponent {
         // `--force` makes the script skip its usage cache TTL, so the manual
         // refresh actually refetches instead of replaying the same cached
         // response. Profile arguments are `name=path`, never a bare flag.
-        command: ["timeout", "120", "bash", root.scriptPath].concat(root.forceFetch ? ["--force"] : []).concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
+        command: ["timeout", "120", "bash", root.scriptPath].concat(root.forceFetch ? ["--force"] : []).concat(root.countBridged ? [] : ["--no-bridged"]).concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
         running: false
 
         stdout: SplitParser {

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -29,7 +29,19 @@ PluginComponent {
     property int refreshInterval: (pluginData.refreshInterval || 2) * 60000
     property bool showPacing: pluginData.showPacing !== false
     property var customProfiles: pluginData.customProfiles || []
-    property bool customProfilesRefreshPending: false
+    // A refresh asked for while one is already in flight. onExited starts it,
+    // so the request is queued rather than dropped.
+    property bool rerunPending: false
+    // Passed to the script as `--force`: manual refresh ignores the usage cache.
+    property bool forceFetch: false
+    // True while the run currently executing is one the user asked for. Read at
+    // exit to decide whether anybody is waiting for a verdict.
+    property bool forcedRunInFlight: false
+    // "ok" | "fail" | "" - the outcome of the last manual refresh, shown on the
+    // button for a few seconds.
+    property string refreshResult: ""
+    // Drives the spinner on the popout refresh button.
+    readonly property bool refreshing: usageProcess.running
 
     // API usage data
     property string subscriptionType: ""
@@ -277,7 +289,9 @@ PluginComponent {
     function usageErrorLabel(code) {
         switch (code) {
         case "token_expired":
-            return tr("Claude Code login expired");
+            // Names the fix, not just the fault: the plugin cannot refresh the
+            // token, only Claude Code itself can, by being run once.
+            return tr("Claude Code login expired - run claude once");
         case "rate_limited":
             return tr("API rate limited");
         case "unauthorized":
@@ -753,13 +767,26 @@ PluginComponent {
 
     // --- Data fetching ---
 
-    // Pick up an added/removed profile now instead of waiting for the refresh timer
-    onCustomProfilesChanged: {
+    // Start a run now, or queue one when a run is already in flight.
+    function rerun() {
         if (usageProcess.running)
-            customProfilesRefreshPending = true;
+            rerunPending = true;
         else
             usageProcess.running = true;
     }
+
+    // Manual refresh from the popout header. Skips the script's usage cache, so
+    // it is also the way out of a stale warning once the login is fixed - the
+    // refresh interval can be 15 minutes, which is a long time to stare at a
+    // warning you have already dealt with.
+    function refreshNow() {
+        refreshResult = "";
+        forceFetch = true;
+        rerun();
+    }
+
+    // Pick up an added/removed profile now instead of waiting for the refresh timer
+    onCustomProfilesChanged: rerun()
 
     Process {
         id: usageProcess
@@ -767,11 +794,23 @@ PluginComponent {
         // while `running` is true, so a single run that never exits (a hung
         // `claude --version`, a stalled curl/find) freezes the widget on stale
         // values until the plugin is reloaded. Killing the run lets onExited fire.
-        command: ["timeout", "120", "bash", root.scriptPath].concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
+        // `--force` makes the script skip its usage cache TTL, so the manual
+        // refresh actually refetches instead of replaying the same cached
+        // response. Profile arguments are `name=path`, never a bare flag.
+        command: ["timeout", "120", "bash", root.scriptPath].concat(root.forceFetch ? ["--force"] : []).concat(root.customProfiles.filter(p => p && p.name && p.path).map(p => p.name + "=" + p.path))
         running: false
 
         stdout: SplitParser {
             onRead: data => root.parseLine(data.trim())
+        }
+
+        // A forced run is the only one a user is waiting on, so its outcome is
+        // reported on the button. Without this a click that ends in the same
+        // numbers - the usual case when the login is dead - looks like a button
+        // that does nothing.
+        onRunningChanged: {
+            if (running)
+                root.forcedRunInFlight = root.forceFetch;
         }
 
         onExited: (exitCode, exitStatus) => {
@@ -779,14 +818,33 @@ PluginComponent {
                 root.isLoading = false;
                 root.refreshEpoch++;
             }
-            if (root.customProfilesRefreshPending) {
-                root.customProfilesRefreshPending = false;
+            if (root.forcedRunInFlight) {
+                root.forcedRunInFlight = false;
+                root.refreshResult = (exitCode === 0 && root.usageError === "") ? "ok" : "fail";
+                refreshResultTimer.restart();
+            }
+            // A run requested while another was in flight is honoured now. The
+            // force flag survives until the run that was asked for has started,
+            // otherwise a manual refresh queued behind a timer tick would lose it.
+            if (root.rerunPending) {
+                root.rerunPending = false;
                 Qt.callLater(function() {
                     if (!usageProcess.running)
                         usageProcess.running = true;
                 });
+            } else {
+                root.forceFetch = false;
             }
         }
+    }
+
+    // Lives on the widget, not in the popout: the popout may be closed before a
+    // slow run finishes, and a dangling timer in a destroyed component would
+    // leave refreshResult set forever.
+    Timer {
+        id: refreshResultTimer
+        interval: 3000
+        onTriggered: root.refreshResult = ""
     }
 
     Timer {
@@ -1045,6 +1103,56 @@ PluginComponent {
                 return label ? root.tr("Subscription") + ": " + label : "";
             }
             showCloseButton: true
+
+            // Manual refresh, styled after the close button next to it. Spins
+            // while a run is in flight, which is also the only feedback that a
+            // click did anything when the numbers come back unchanged.
+            headerActions: Component {
+                Rectangle {
+                    width: 32
+                    height: 32
+                    radius: 16
+                    color: refreshArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.12) : "transparent"
+
+                    DankIcon {
+                        id: refreshIcon
+                        anchors.centerIn: parent
+                        // The icon carries the verdict for a few seconds: a check
+                        // when the numbers are live again, an error mark when the
+                        // fetch failed and the warning below still stands.
+                        name: root.refreshResult === "ok" ? "check" : root.refreshResult === "fail" ? "error" : "refresh"
+                        size: Theme.iconSize - 4
+                        color: {
+                            if (root.refreshResult === "fail")
+                                return Theme.error;
+                            if (root.refreshResult === "ok")
+                                return Theme.primary;
+                            return refreshArea.containsMouse ? Theme.primary : Theme.surfaceVariantText;
+                        }
+
+                        RotationAnimator {
+                            target: refreshIcon
+                            from: 0
+                            to: 360
+                            duration: 1000
+                            loops: Animation.Infinite
+                            running: root.refreshing
+                            onRunningChanged: {
+                                if (!running)
+                                    refreshIcon.rotation = 0;
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        id: refreshArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.refreshNow()
+                    }
+                }
+            }
 
             Column {
                 width: parent.width - Theme.spacingM * 2

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -16,14 +16,31 @@ PluginComponent {
         return Tr.tr(key, lang);
     }
 
-    // Calendar week labels: Monday to Sunday (fixed order)
+    // Weekday labels, Monday first. The Daily Activity strip starts on whatever
+    // day the rate limit window does, so the row is rotated to match instead of
+    // always reading Mo..Su - see dayLabels below.
     property int refreshEpoch: 0
     readonly property var dayLabelsByLanguage: ({
         en: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
         fr: ["Lu", "Ma", "Me", "Je", "Ve", "Sa", "Di"],
         es: ["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"]
     })
-    property var dayLabels: dayLabelsByLanguage[lang] || dayLabelsByLanguage.en
+    readonly property var weekdayNames: dayLabelsByLanguage[lang] || dayLabelsByLanguage.en
+    property var dayLabels: rotateWeekdays(weekdayNames, displayWeekWindowStart)
+
+    // `base` is Monday-first; rotate it so index 0 is the weekday `windowStart`
+    // falls on. An unusable date leaves the row Monday-first, which is also what
+    // the script buckets by when it has no window to align to.
+    function rotateWeekdays(base, windowStart) {
+        var d = new Date(windowStart + "T00:00:00");
+        if (isNaN(d.getTime()))
+            return base;
+        var startDow = (d.getDay() + 6) % 7;
+        var out = [];
+        for (var i = 0; i < 7; i++)
+            out.push(base[(startDow + i) % 7]);
+        return out;
+    }
 
     // Settings
     property int refreshInterval: (pluginData.refreshInterval || 2) * 60000
@@ -77,8 +94,11 @@ PluginComponent {
     property int alltimeMessages: 0
     property string firstSession: ""
 
-    // Daily breakdown (rolling 7 days, computed from JSONL files)
+    // The seven days of the rate limit window, in order, computed from JSONL files
     property var dailyTokens: [0, 0, 0, 0, 0, 0, 0]
+    // Counted by date rather than read out of the strip: on the morning of a
+    // reset day, today is not one of the seven days the strip covers.
+    property real todayTokens: 0
 
     // Estimated API cost (in USD)
     property real todayCost: 0
@@ -162,6 +182,7 @@ PluginComponent {
     property real displayWeekCost: currentPd && currentPd.weekCost !== undefined ? currentPd.weekCost : weekCost
     property real displayMonthCost: currentPd && currentPd.monthCost !== undefined ? currentPd.monthCost : monthCost
     property var displayDailyTokens: currentPd && currentPd.daily ? currentPd.daily : dailyTokens
+    property real displayTodayTokens: currentPd && currentPd.todayTokens !== undefined ? currentPd.todayTokens : todayTokens
 
     // Per-profile daily tokens for chart overlay. Empty array when "all" selected.
     property var profileDailyTokens: currentPd && currentPd.daily ? currentPd.daily : []
@@ -217,11 +238,26 @@ PluginComponent {
     // the horizontal and vertical pills so they never diverge.
     readonly property bool pillOverPace: showPacing && (pillFivePace.status === "over" || pillFivePace.status === "over_quota")
 
-    // Today's index in the calendar week (0=Monday, 6=Sunday)
+    // Where today sits in the seven days the strip covers, or -1 when it sits
+    // outside them - which happens between midnight and a reset later the same
+    // day, when the window on screen is still the one about to close.
     property int todayIndex: {
         void (countdownNow);
-        var dow = new Date().getDay(); // 0=Sunday, 6=Saturday
-        return dow === 0 ? 6 : dow - 1;
+        return windowDayIndex(displayWeekWindowStart, new Date());
+    }
+
+    // Column 0..6 of the strip that `when` falls in, or -1 outside the window.
+    // Compares calendar dates, so it never drifts with the time of day.
+    function windowDayIndex(windowStart, when) {
+        var start = new Date(windowStart + "T00:00:00");
+        if (isNaN(start.getTime()))
+            return -1;
+        var day = new Date(when.getFullYear(), when.getMonth(), when.getDate());
+        var diff = day.getTime() - start.getTime();
+        // Both ends are local midnights, so rounding absorbs the 23h and 25h
+        // days that daylight saving produces.
+        var days = Math.round(diff / 86400000);
+        return days >= 0 && days <= 6 ? days : -1;
     }
 
     // Derived
@@ -290,6 +326,16 @@ PluginComponent {
         if (n >= 1000)
             return (n / 1000).toFixed(1) + "K";
         return Math.round(n).toString();
+    }
+
+    // Calendar date of strip column `index`, as "Mon 10 Aug". The strip no longer
+    // starts on Monday, so a bare weekday label is not enough to place a bar.
+    function dayDate(index) {
+        var d = new Date(displayWeekWindowStart + "T00:00:00");
+        if (isNaN(d.getTime()) || index < 0)
+            return "";
+        d.setDate(d.getDate() + index);
+        return Qt.formatDate(d, "ddd d MMM");
     }
 
     // Seconds → "45m" / "3h 37m" / "2d 4h". Used for how old stale numbers are.
@@ -608,6 +654,9 @@ PluginComponent {
         case "MONTH_TOKENS":
             monthTokens = parseFloat(val) || 0;
             break;
+        case "TODAY_TOKENS":
+            todayTokens = parseFloat(val) || 0;
+            break;
         case "ALLTIME_SESSIONS":
             alltimeSessions = parseInt(val) || 0;
             break;
@@ -686,6 +735,9 @@ PluginComponent {
             break;
         case "PROFILE_MONTH_TOKENS":
             profileData = parseProfileSimple(val, "monthTokens", false);
+            break;
+        case "PROFILE_TODAY_TOKENS":
+            profileData = parseProfileSimple(val, "todayTokens", false);
             break;
         case "PROFILE_WEEK_MESSAGES":
             profileData = parseProfileSimple(val, "weekMessages", false);
@@ -1509,7 +1561,7 @@ PluginComponent {
                                     anchors.horizontalCenter: parent.horizontalCenter
                                 }
                                 StyledText {
-                                    text: root.formatTokens(root.displayDailyTokens[root.todayIndex])
+                                    text: root.formatTokens(root.displayTodayTokens)
                                     font.pixelSize: Theme.fontSizeLarge
                                     font.weight: Font.DemiBold
                                     color: Theme.primary
@@ -1703,6 +1755,15 @@ PluginComponent {
                             id: tooltipCol
                             anchors.centerIn: parent
                             spacing: 1
+
+                            // Line 0: which day this bar is, since the strip can
+                            // start on any weekday
+                            StyledText {
+                                text: root.dayDate(root.hoveredDay)
+                                font.pixelSize: 10
+                                color: Theme.surfaceVariantText
+                                anchors.horizontalCenter: parent.horizontalCenter
+                            }
 
                             // Line 1: total tokens (with "total" suffix when a profile is selected)
                             StyledText {

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -56,6 +56,13 @@ PluginComponent {
     // being shown are, in seconds (0 = there is no data at all).
     property int usageAge: 0
     property string usageError: ""
+    // Per-model weekly limits, the rows claude.ai shows under the all-models
+    // one: [{ name, percent }]. Empty when the plan has no scoped model.
+    property var weeklyScoped: []
+    // First day (YYYY-MM-DD, local) of the window the week totals below cover.
+    // It is the rate limit week, which does not start on Monday, so the totals
+    // sit next to the 7-day ring measuring the same days.
+    property string weekWindowStart: ""
 
     // Weekly state
     property int weekMessages: 0
@@ -120,6 +127,18 @@ PluginComponent {
     property string displaySevenDayReset: currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
     property int displayUsageAge: currentPd && currentPd.usageAge !== undefined ? currentPd.usageAge : usageAge
     property string displayUsageError: currentPd && currentPd.usageError !== undefined ? currentPd.usageError : usageError
+    property var displayWeeklyScoped: currentPd && currentPd.weeklyScoped !== undefined ? currentPd.weeklyScoped : weeklyScoped
+    property string displayWeekWindowStart: currentPd && currentPd.weekWindowStart !== undefined ? currentPd.weekWindowStart : weekWindowStart
+    // "Since Aug 6" - which days the week totals in this card cover. Empty until
+    // a window is known, so nothing is claimed before the first fetch lands.
+    property string weekWindowLabel: {
+        if (!displayWeekWindowStart)
+            return "";
+        var d = new Date(displayWeekWindowStart + "T00:00:00");
+        if (isNaN(d.getTime()))
+            return "";
+        return tr("Since") + " " + Qt.formatDate(d, "MMM d");
+    }
 
     // One line telling the user the rate limit numbers are not live, and why.
     // Empty while the fetch is healthy, which is the normal case.
@@ -495,6 +514,28 @@ PluginComponent {
         }
         return _pd;
     }
+    // "Fable:6,Opus:12" -> [{ name: "Fable", percent: 6 }, ...]. The script strips
+    // `,` `:` `|` from model names, so splitting on them here is safe.
+    function parseScopedLimits(val) {
+        var out = [];
+        if (!val)
+            return out;
+        var entries = val.split(",");
+        for (var i = 0; i < entries.length; i++) {
+            var colon = entries[i].lastIndexOf(":");
+            if (colon <= 0)
+                continue;
+            var name = entries[i].substring(0, colon);
+            var pct = parseFloat(entries[i].substring(colon + 1));
+            if (name === "" || isNaN(pct))
+                continue;
+            out.push({
+                name: name,
+                percent: pct
+            });
+        }
+        return out;
+    }
 
     function parseProfileBool(val, field) {
         var _pd = Object.assign({}, profileData);
@@ -548,6 +589,12 @@ PluginComponent {
             break;
         case "USAGE_ERROR":
             usageError = val;
+            break;
+        case "WEEKLY_SCOPED":
+            weeklyScoped = parseScopedLimits(val);
+            break;
+        case "WEEK_WINDOW_START":
+            weekWindowStart = val;
             break;
         case "WEEK_MESSAGES":
             weekMessages = parseInt(val) || 0;
@@ -682,6 +729,29 @@ PluginComponent {
         case "PROFILE_USAGE_ERROR":
             profileData = parseProfileString(val, "usageError");
             break;
+        case "PROFILE_WEEK_WINDOW_START":
+            profileData = parseProfileString(val, "weekWindowStart");
+            break;
+        case "PROFILE_WEEKLY_SCOPED":
+            {
+                // Pipe-separated because the value itself holds `Model:percent`
+                // pairs joined by commas, same shape as PROFILE_WEEK_MODELS.
+                var _pd4 = Object.assign({}, profileData);
+                var blocks4 = val.split("|");
+                for (var bi4 = 0; bi4 < blocks4.length; bi4++) {
+                    var c4 = blocks4[bi4].indexOf(":");
+                    if (c4 < 0)
+                        continue;
+                    var pname4 = blocks4[bi4].substring(0, c4);
+                    if (!_pd4[pname4])
+                        _pd4[pname4] = {};
+                    else
+                        _pd4[pname4] = Object.assign({}, _pd4[pname4]);
+                    _pd4[pname4].weeklyScoped = parseScopedLimits(blocks4[bi4].substring(c4 + 1));
+                }
+                profileData = _pd4;
+                break;
+            }
         case "PROFILE_DAILY":
             {
                 var _pd1 = Object.assign({}, profileData);
@@ -1355,6 +1425,20 @@ PluginComponent {
                                 color: Theme.surfaceText
                                 wrapMode: Text.WordWrap
                             }
+                            // One row per model that has its own weekly cap. The
+                            // all-models ring can sit at 71% while a single model
+                            // is at 6%, so these are not derivable from it.
+                            Repeater {
+                                model: root.displayWeeklyScoped
+                                StyledText {
+                                    required property var modelData
+                                    width: parent.width
+                                    text: modelData.name + " · " + Math.round(modelData.percent) + "%" + root.staleMark
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    color: root.progressColor(modelData.percent)
+                                    wrapMode: Text.WordWrap
+                                }
+                            }
                             StyledText {
                                 width: parent.width
                                 text: root.paceLabel(root.sevenDayPace)
@@ -1371,6 +1455,8 @@ PluginComponent {
                                         parts.push(root.displayWeekSessions + " " + root.tr("sessions"));
                                     if (root.displayWeekMessages > 0)
                                         parts.push(root.displayWeekMessages + " " + root.tr("msgs"));
+                                    if (root.weekWindowLabel !== "")
+                                        parts.push(root.weekWindowLabel);
                                     return parts.join(" · ");
                                 }
                                 font.pixelSize: Theme.fontSizeSmall

--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -289,8 +289,9 @@ PluginComponent {
     function usageErrorLabel(code) {
         switch (code) {
         case "token_expired":
-            // Names the fix, not just the fault: the plugin cannot refresh the
-            // token, only Claude Code itself can, by being run once.
+            // The script renews the access token itself, so this only appears
+            // when the refresh token is dead too - and then a `claude` run is
+            // genuinely the only fix. Names it instead of just the fault.
             return tr("Claude Code login expired - run claude once");
         case "rate_limited":
             return tr("API rate limited");

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Profile overlay on the daily activity chart: grey bars show total usage, colored bars show the selected profile's share
   - Tooltip shows both total and per-profile token counts when a profile is selected
 - **Automatic subscription detection** via the Anthropic OAuth API
+- **Automatic token renewal** — the ~12h OAuth access token is refreshed with the stored refresh token when it expires, so the widget keeps working through the days you never launch Claude Code
 - **Dynamic model pricing** — new Anthropic model families are detected automatically, no code changes needed
 - **Currency support** — costs displayed in EUR for French locale, USD otherwise (exchange rate from ECB via [Frankfurter](https://www.frankfurter.app/))
 - **Configurable refresh interval** (2 to 15 minutes)
@@ -82,14 +83,14 @@ an auto-detected profile is skipped.
 
 The plugin runs a lightweight bash script at the configured interval that:
 
-1. Reads your OAuth token from `~/.claude/.credentials.json`
+1. Reads your OAuth token from `~/.claude/.credentials.json`, and renews it with the stored refresh token when it has expired (the same `refresh_token` grant Claude Code itself uses)
 2. Queries the Anthropic usage API for current rate limit status
 3. Scans `<config dir>/projects/` for every discovered profile (see above) for token consumption statistics — each profile is processed in parallel
 4. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
 
-API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting; the popout refresh button skips that cache. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — an expired login in `~/.claude/.credentials.json` (run `claude` once to refresh it), a rate limit, or no connection.
+API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting; the popout refresh button skips that cache. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — a login that not even the refresh token can save (run `claude` once), a rate limit, or no connection.
 
-All data stays local. Network requests are limited to the official Anthropic API (usage), GitHub (LiteLLM pricing, once/day), and Frankfurter (exchange rate, once/day).
+All data stays local. Network requests are limited to the official Anthropic API (usage), the Claude OAuth token endpoint (only when the access token has to be renewed), GitHub (LiteLLM pricing, once/day), and Frankfurter (exchange rate, once/day).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Any directory you add manually under **Custom Profiles** in the plugin settings
   - Profile overlay on the daily activity chart: grey bars show total usage, colored bars show the selected profile's share
   - Tooltip shows both total and per-profile token counts when a profile is selected
+- **Counts every client on the subscription** — an agent harness that reaches Anthropic through a bridge (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) spends the same rate limit budget while writing its transcripts elsewhere, so those Claude calls are counted too. Without it a day spent in such a client reads as "today: 0 tokens" under a 5-hour ring that says 16% used. Currently detects [pi](https://github.com/badlogic/pi-mono) transcripts (`~/.pi/agent/sessions/`, `~/.pi/profiles/*/sessions/`, or `$PI_CONFIG_DIR`); only Claude models are counted, and can be turned off in the settings
 - **Automatic subscription detection** via the Anthropic OAuth API
 - **Automatic token renewal** — the ~12h OAuth access token is refreshed with the stored refresh token when it expires, so the widget keeps working through the days you never launch Claude Code
 - **Dynamic model pricing** — new Anthropic model families are detected automatically, no code changes needed
@@ -62,7 +63,8 @@ Then restart DMS.
 ## Configuration
 
 Open DMS Settings (`Mod + ,` > Plugins > Claude Code Usage) to adjust the refresh interval,
-toggle pacing indicators, and register custom profiles.
+toggle pacing indicators, toggle counting of other clients on the subscription, and
+register custom profiles.
 
 ### Custom Profiles
 
@@ -87,7 +89,8 @@ The plugin runs a lightweight bash script at the configured interval that:
 1. Reads your OAuth token from `~/.claude/.credentials.json`, and renews it with the stored refresh token when it has expired (the same `refresh_token` grant Claude Code itself uses)
 2. Queries the Anthropic usage API for current rate limit status
 3. Scans `<config dir>/projects/` for every discovered profile (see above) for token consumption statistics — each profile is processed in parallel
-4. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
+4. Scans the transcripts of other clients on the same subscription (pi sessions, unless **Count other clients** is off) and attributes their Claude calls to the `default` profile, since they bill the login whose rate limits the popout shows. Where such a transcript records its own cost, that cost is used — it prices the exact model that answered, including ones LiteLLM has never heard of
+5. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
 
 API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting; the popout refresh button skips that cache. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — a login that not even the refresh token can save (run `claude` once), a rate limit, or no connection.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Per-model weekly limits under the 7-day ring — claude.ai gives some models their own weekly cap, so the all-models ring can sit at 71% while a single model is at 6%
   - Token consumption breakdown (today, the current rate limit week, calendar month). The week totals cover the seven days the 7-day ring measures, which start when the limit last reset, not Monday - the card says which day they start from
   - Estimated API cost per period (today, week, calendar month) with automatic pricing from [LiteLLM](https://github.com/BerriAI/litellm)
-  - Weekly activity bar chart (Monday–Sunday) with interactive hover tooltips (token count + cost)
+  - Daily activity bar chart covering the same seven days as the 7-day ring, so the bars add up to the week total above them. It starts on the day the limit last reset, so the weekday labels rotate with the window and each tooltip names its date (token count + cost)
   - Per-model token usage for the current rate limit week with dynamic model family detection
   - All-time session and message statistics
 - **Profile breakdown** — per-profile token/cost stats with a hybrid profile selector (tabs for up to 4 profiles, dropdown for more). Profiles are discovered automatically from:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
 - **Taskbar pill** with circular progress ring showing 5-hour rate limit utilization
 - **Detailed popout** with:
   - 5-hour and 7-day rate window utilization with countdown timers
-  - Stale-data warning when the usage API cannot be reached — the pill dims and adds `?`, and the popout says how old the numbers are and why the fetch failed (e.g. `3h 40m old · Claude Code login expired`), instead of presenting cached numbers as live
+  - Stale-data warning when the usage API cannot be reached — the pill dims and adds `?`, and the popout says how old the numbers are and what to do about it (e.g. `3h 40m old · Claude Code login expired - run claude once`), instead of presenting cached numbers as live
+  - Refresh button in the popout header for an immediate fetch that ignores the cache — after fixing an expired login you see the real numbers straight away instead of waiting out the refresh interval
   - Pacing indicator showing whether you're over or under a linear burn rate for each window (e.g. "6% over pace", "25% under pace")
   - Token consumption breakdown (today, calendar week, calendar month)
   - Estimated API cost per period (today, calendar week, calendar month) with automatic pricing from [LiteLLM](https://github.com/BerriAI/litellm)
@@ -86,7 +87,7 @@ The plugin runs a lightweight bash script at the configured interval that:
 3. Scans `<config dir>/projects/` for every discovered profile (see above) for token consumption statistics — each profile is processed in parallel
 4. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
 
-API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — an expired login in `~/.claude/.credentials.json` (run `claude` once to refresh it), a rate limit, or no connection.
+API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting; the popout refresh button skips that cache. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — an expired login in `~/.claude/.credentials.json` (run `claude` once to refresh it), a rate limit, or no connection.
 
 All data stays local. Network requests are limited to the official Anthropic API (usage), GitHub (LiteLLM pricing, once/day), and Frankfurter (exchange rate, once/day).
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
 - **Taskbar pill** with circular progress ring showing 5-hour rate limit utilization
 - **Detailed popout** with:
   - 5-hour and 7-day rate window utilization with countdown timers
+  - Stale-data warning when the usage API cannot be reached — the pill dims and adds `?`, and the popout says how old the numbers are and why the fetch failed (e.g. `3h 40m old · Claude Code login expired`), instead of presenting cached numbers as live
   - Pacing indicator showing whether you're over or under a linear burn rate for each window (e.g. "6% over pace", "25% under pace")
   - Token consumption breakdown (today, calendar week, calendar month)
   - Estimated API cost per period (today, calendar week, calendar month) with automatic pricing from [LiteLLM](https://github.com/BerriAI/litellm)
@@ -85,7 +86,7 @@ The plugin runs a lightweight bash script at the configured interval that:
 3. Scans `<config dir>/projects/` for every discovered profile (see above) for token consumption statistics — each profile is processed in parallel
 4. Fetches model pricing from LiteLLM and USD/EUR exchange rate from ECB (cached daily in `~/.claude/pricing-cache.json`)
 
-API usage responses are cached for 2 minutes (`~/.claude/usage-cache.json`) to avoid rate limiting, with stale fallback on errors.
+API usage responses are cached for 90 seconds (`~/.claude/usage-cache.json`) to avoid rate limiting. If a fetch fails the cached numbers are still shown, but they are labelled with their age and the reason the fetch failed — an expired login in `~/.claude/.credentials.json` (run `claude` once to refresh it), a rate limit, or no connection.
 
 All data stays local. Network requests are limited to the official Anthropic API (usage), GitHub (LiteLLM pricing, once/day), and Frankfurter (exchange rate, once/day).
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ A [DMS (Dank Material Shell)](https://github.com/AvengeMedia/DankMaterialShell) 
   - Stale-data warning when the usage API cannot be reached — the pill dims and adds `?`, and the popout says how old the numbers are and what to do about it (e.g. `3h 40m old · Claude Code login expired - run claude once`), instead of presenting cached numbers as live
   - Refresh button in the popout header for an immediate fetch that ignores the cache — after fixing an expired login you see the real numbers straight away instead of waiting out the refresh interval
   - Pacing indicator showing whether you're over or under a linear burn rate for each window (e.g. "6% over pace", "25% under pace")
-  - Token consumption breakdown (today, calendar week, calendar month)
-  - Estimated API cost per period (today, calendar week, calendar month) with automatic pricing from [LiteLLM](https://github.com/BerriAI/litellm)
+  - Per-model weekly limits under the 7-day ring — claude.ai gives some models their own weekly cap, so the all-models ring can sit at 71% while a single model is at 6%
+  - Token consumption breakdown (today, the current rate limit week, calendar month). The week totals cover the seven days the 7-day ring measures, which start when the limit last reset, not Monday - the card says which day they start from
+  - Estimated API cost per period (today, week, calendar month) with automatic pricing from [LiteLLM](https://github.com/BerriAI/litellm)
   - Weekly activity bar chart (Monday–Sunday) with interactive hover tooltips (token count + cost)
-  - Per-model token usage for the current calendar week with dynamic model family detection
+  - Per-model token usage for the current rate limit week with dynamic model family detection
   - All-time session and message statistics
 - **Profile breakdown** — per-profile token/cost stats with a hybrid profile selector (tabs for up to 4 profiles, dropdown for more). Profiles are discovered automatically from:
   - `~/.claude` (the `default` profile)

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -248,19 +248,168 @@ count_profile_tokens() {
         }' > "$out_file" 2>/dev/null || true
 }
 
+# --- OAuth token refresh ---
+# The access token in `.credentials.json` lives ~12h. Claude Code renews it when
+# it runs, so a user whose daily driver is Claude Code never notices. For everyone
+# else the token dies and every usage fetch from here on is refused, which froze
+# this widget on hours-old numbers. So do the refresh ourselves: the endpoint,
+# client id and body below are exactly what Claude Code 2.1.x sends (`TOKEN_URL`,
+# `CLIENT_ID` and its `grant_type=refresh_token` call in its own bundle).
+OAUTH_TOKEN_URL="https://platform.claude.com/v1/oauth/token"
+OAUTH_CLIENT_ID="9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+OAUTH_SCOPES="user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
+# Not `claude-code/<version>`: that exact string is throttled at the edge of the
+# token endpoint (measured: HTTP 429 in 20ms before the grant is even looked at,
+# while any other agent string gets a real answer). We are not Claude Code, so we
+# say who we are.
+OAUTH_USER_AGENT="dms-claudecode"
+# How long a failed refresh is left alone. The widget fetches every 2 minutes, so
+# without this a permanently dead refresh token would hammer the endpoint forever.
+REFRESH_BACKOFF=600  # seconds
+
+# Usage: refresh_oauth_token <credentials_file> <backoff_stamp_file>
+# Echoes a usable access token and returns 0, or returns 1 and prints nothing.
+# A failure leaves `<epoch> <http_code>` in the stamp file: the epoch gates the
+# retry, the code lets the caller say "rate limited" instead of "log in again".
+#
+# This is the one place the plugin writes a file it does not own, so it is
+# deliberately timid: the credentials file is replaced only when the response
+# parsed completely AND nobody rotated the refresh token while the request was in
+# flight. A half-written credentials file breaks the user's Claude Code login,
+# which is far worse than a widget showing stale numbers.
+refresh_oauth_token() {
+    local creds_file="$1" stamp_file="$2"
+    local now_ts refresh_token refresh_exp stamp scopes raw http_code body
+    local access_token new_refresh expires_in refresh_expires_in
+    local expires_ms refresh_expires_ms current_refresh other_token tmp_file
+
+    now_ts=$(date +%s)
+
+    refresh_token=$(jq -r '.claudeAiOauth.refreshToken // ""' "$creds_file" 2>/dev/null | head -1)
+    [ -n "$refresh_token" ] || return 1
+
+    # An expired refresh token can only be replaced by `claude auth login`, and
+    # spending a request to be told that helps nobody.
+    refresh_exp=$(jq -r '.claudeAiOauth.refreshTokenExpiresAt // 0' "$creds_file" 2>/dev/null | head -1)
+    [[ "$refresh_exp" =~ ^[0-9]+$ ]] || refresh_exp=0
+    if [ "$refresh_exp" -gt 0 ] && [ $(( refresh_exp / 1000 )) -le "$now_ts" ]; then
+        return 1
+    fi
+
+    if [ -f "$stamp_file" ]; then
+        stamp=$(awk 'NR==1 {print $1}' "$stamp_file" 2>/dev/null || echo 0)
+        [[ "$stamp" =~ ^[0-9]+$ ]] || stamp=0
+        if [ $(( now_ts - stamp )) -lt "$REFRESH_BACKOFF" ]; then
+            return 1
+        fi
+    fi
+
+    # Ask for the scopes the login already has; the hardcoded list is only a
+    # fallback for a credentials file written before scopes were stored.
+    scopes=$(jq -r '(.claudeAiOauth.scopes // []) | join(" ")' "$creds_file" 2>/dev/null | head -1)
+    [ -n "$scopes" ] || scopes="$OAUTH_SCOPES"
+
+    raw=$(curl -s -w '\n%{http_code}' --max-time 15 -X POST \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        -H "User-Agent: ${OAUTH_USER_AGENT}" \
+        -d "$(jq -nc --arg rt "$refresh_token" --arg cid "$OAUTH_CLIENT_ID" --arg scope "$scopes" \
+                '{grant_type: "refresh_token", refresh_token: $rt, client_id: $cid, scope: $scope}')" \
+        "$OAUTH_TOKEN_URL" 2>/dev/null) || raw=""
+
+    http_code="${raw##*$'\n'}"
+    body="${raw%$'\n'*}"
+    [[ "$http_code" =~ ^[0-9]{3}$ ]] || http_code=000
+
+    access_token=""; new_refresh=""; expires_in=0; refresh_expires_in=0
+    if [ "$http_code" = 200 ]; then
+        access_token=$(echo "$body" | jq -r '.access_token // ""' 2>/dev/null | head -1)
+        new_refresh=$(echo "$body" | jq -r '.refresh_token // ""' 2>/dev/null | head -1)
+        expires_in=$(echo "$body" | jq -r '.expires_in // 0' 2>/dev/null | head -1)
+        refresh_expires_in=$(echo "$body" | jq -r '.refresh_token_expires_in // 0' 2>/dev/null | head -1)
+    fi
+    [[ "$expires_in" =~ ^[0-9]+$ ]] || expires_in=0
+    [[ "$refresh_expires_in" =~ ^[0-9]+$ ]] || refresh_expires_in=0
+
+    if [ -z "$access_token" ] || [ "$expires_in" -le 0 ]; then
+        printf '%s %s\n' "$now_ts" "$http_code" > "$stamp_file" 2>/dev/null || true
+        return 1
+    fi
+
+    # The server rotates the refresh token on use, so an omitted one means "keep
+    # the old one", not "drop it".
+    [ -n "$new_refresh" ] || new_refresh="$refresh_token"
+    expires_ms=$(( (now_ts + expires_in) * 1000 ))
+    refresh_expires_ms=0
+    [ "$refresh_expires_in" -gt 0 ] && refresh_expires_ms=$(( (now_ts + refresh_expires_in) * 1000 ))
+
+    # Claude Code, or a parallel run of this script, may have refreshed while our
+    # request was in flight. Their token is as good as ours and the server has
+    # already retired the one we sent, so take theirs and leave the file alone.
+    current_refresh=$(jq -r '.claudeAiOauth.refreshToken // ""' "$creds_file" 2>/dev/null | head -1)
+    if [ "$current_refresh" != "$refresh_token" ]; then
+        other_token=$(jq -r '.claudeAiOauth.accessToken // ""' "$creds_file" 2>/dev/null | head -1)
+        [ -n "$other_token" ] || return 1
+        rm -f "$stamp_file" 2>/dev/null || true
+        printf '%s\n' "$other_token"
+        return 0
+    fi
+
+    # Merge, never rewrite: the file carries keys this script does not know about
+    # (`mcpOAuth`, subscription details) and losing them would break the login.
+    # `umask 077` keeps the 0600 mode across the rename.
+    tmp_file="${creds_file}.$$.tmp"
+    if ! ( umask 077; jq --arg at "$access_token" --arg rt "$new_refresh" \
+            --argjson exp "$expires_ms" --argjson rexp "$refresh_expires_ms" \
+            --arg scope "$(echo "$body" | jq -r '.scope // ""' 2>/dev/null | head -1)" '
+            .claudeAiOauth.accessToken = $at
+            | .claudeAiOauth.refreshToken = $rt
+            | .claudeAiOauth.expiresAt = $exp
+            | if $rexp > 0 then .claudeAiOauth.refreshTokenExpiresAt = $rexp else . end
+            | if ($scope | length) > 0 then .claudeAiOauth.scopes = ($scope | split(" ")) else . end
+        ' "$creds_file" > "$tmp_file" 2>/dev/null ); then
+        rm -f "$tmp_file"
+        printf '%s %s\n' "$now_ts" "$http_code" > "$stamp_file" 2>/dev/null || true
+        return 1
+    fi
+
+    # Verify the merge landed before overwriting a working login: a truncated or
+    # empty temp file would otherwise become the user's credentials.
+    if ! jq -e --arg at "$access_token" '.claudeAiOauth.accessToken == $at' "$tmp_file" >/dev/null 2>&1; then
+        rm -f "$tmp_file"
+        printf '%s %s\n' "$now_ts" "$http_code" > "$stamp_file" 2>/dev/null || true
+        return 1
+    fi
+
+    mv -f "$tmp_file" "$creds_file" 2>/dev/null || { rm -f "$tmp_file"; return 1; }
+    rm -f "$stamp_file" 2>/dev/null || true
+    printf '%s\n' "$access_token"
+}
+
 # Why did the usage fetch fail? Short stable tokens, the widget maps them to text.
-# Usage: classify_usage_error <credentials_file> <now_epoch> <http_code>
-# An expired OAuth token wins over the HTTP code: the widget only reads
-# `.credentials.json`, it never refreshes it, so a stale login keeps failing until
-# Claude Code runs again - that is the actionable cause, whatever the API answered.
+# Usage: classify_usage_error <credentials_file> <now_epoch> <http_code> [refresh_stamp]
+# An expired OAuth token wins over the HTTP code: it is the cause the user can act
+# on. The script refreshes the token itself (see `refresh_oauth_token`), so seeing
+# this reason means even the refresh could not save it - the refresh token is gone
+# too, and only `claude` running once will fix the login. Unless the refresh was
+# throttled rather than refused: then the login is fine and the advice would be
+# wrong, so the stamp's HTTP code overrides it.
 classify_usage_error() {
-    local creds_file="$1" now_ts="$2" http_code="$3"
-    local expires_ms
+    local creds_file="$1" now_ts="$2" http_code="$3" refresh_stamp="${4:-}"
+    local expires_ms refresh_code
 
     expires_ms=$(jq -r '.claudeAiOauth.expiresAt // 0' "$creds_file" 2>/dev/null | head -1)
     [[ "$expires_ms" =~ ^[0-9]+$ ]] || expires_ms=0
     if [ "$expires_ms" -gt 0 ] && [ $(( expires_ms / 1000 )) -le "$now_ts" ]; then
-        echo "token_expired"
+        refresh_code=""
+        if [ -n "$refresh_stamp" ] && [ -f "$refresh_stamp" ]; then
+            refresh_code=$(awk 'NR==1 {print $2}' "$refresh_stamp" 2>/dev/null || echo "")
+        fi
+        if [ "$refresh_code" = 429 ]; then
+            echo "rate_limited"
+        else
+            echo "token_expired"
+        fi
         return
     fi
 
@@ -332,29 +481,62 @@ fetch_profile_usage() {
     if [ "$use_cache" = true ]; then
         api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
     else
-        local token
+        local token expires_ms refreshed=false new_token
+        local refresh_stamp="${cache_file%.json}-refresh.stamp"
         token=$(jq -r '.claudeAiOauth.accessToken // ""' "$creds_file" 2>/dev/null || echo "")
+        expires_ms=$(jq -r '.claudeAiOauth.expiresAt // 0' "$creds_file" 2>/dev/null | head -1)
+        [[ "$expires_ms" =~ ^[0-9]+$ ]] || expires_ms=0
+
+        # Renew before spending the request: a token that is already dead - or dies
+        # within the minute - cannot serve this fetch anyway. `refreshed` is set
+        # even when the attempt fails, so the 401 path below never doubles up.
+        if [ -n "$token" ] && [ "$expires_ms" -gt 0 ] && [ $(( expires_ms / 1000 )) -le $(( now_ts + 60 )) ]; then
+            if new_token=$(refresh_oauth_token "$creds_file" "$refresh_stamp"); then
+                token="$new_token"
+            fi
+            refreshed=true
+        fi
+
         if [ -z "$token" ]; then
             usage_error="no_credentials"
         else
-            # `-w` appends the status on its own line, so the body is everything
-            # before it. Needed to tell "rate limited" from "offline" from a
-            # dead token - all three otherwise look like an empty response.
             local http_code=000
             local raw=""
-            raw=$(curl -s -w '\n%{http_code}' --max-time 5 \
-                -H "Authorization: Bearer $token" \
-                -H "Accept: application/json" \
-                -H "Content-Type: application/json" \
-                -H "User-Agent: claude-code/${CLAUDE_VERSION}" \
-                -H "anthropic-beta: oauth-2025-04-20" \
-                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || raw=""
-            if [ -n "$raw" ]; then
-                http_code="${raw##*$'\n'}"
-                api_resp="${raw%$'\n'*}"
-                [[ "$http_code" =~ ^[0-9]{3}$ ]] || http_code=000
-                [ -n "$api_resp" ] || api_resp="{}"
-            fi
+            local attempt
+            for attempt in 1 2; do
+                http_code=000
+                raw=""
+                api_resp="{}"
+                # `-w` appends the status on its own line, so the body is everything
+                # before it. Needed to tell "rate limited" from "offline" from a
+                # dead token - all three otherwise look like an empty response.
+                raw=$(curl -s -w '\n%{http_code}' --max-time 5 \
+                    -H "Authorization: Bearer $token" \
+                    -H "Accept: application/json" \
+                    -H "Content-Type: application/json" \
+                    -H "User-Agent: claude-code/${CLAUDE_VERSION}" \
+                    -H "anthropic-beta: oauth-2025-04-20" \
+                    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || raw=""
+                if [ -n "$raw" ]; then
+                    http_code="${raw##*$'\n'}"
+                    api_resp="${raw%$'\n'*}"
+                    [[ "$http_code" =~ ^[0-9]{3}$ ]] || http_code=000
+                    [ -n "$api_resp" ] || api_resp="{}"
+                fi
+
+                # A 401 on a token the file still calls valid means the server
+                # retired it early. One refresh, one retry, never a loop.
+                if [ "$http_code" = 401 ] && [ "$refreshed" = false ]; then
+                    refreshed=true
+                    if new_token=$(refresh_oauth_token "$creds_file" "$refresh_stamp"); then
+                        if [ "$new_token" != "$token" ]; then
+                            token="$new_token"
+                            continue
+                        fi
+                    fi
+                fi
+                break
+            done
 
             if echo "$api_resp" | jq -e '.five_hour' >/dev/null 2>&1; then
                 # Write atomically: overlapping widget refreshes both target the
@@ -368,7 +550,7 @@ fetch_profile_usage() {
                     rm -f "$cache_tmp"
                 fi
             else
-                usage_error=$(classify_usage_error "$creds_file" "$now_ts" "$http_code")
+                usage_error=$(classify_usage_error "$creds_file" "$now_ts" "$http_code" "$refresh_stamp")
                 if [ "$cache_matches" = true ]; then
                     api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
                     usage_age="$cache_age"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -27,6 +27,8 @@ FIVE_HOUR_RESET=""
 SEVEN_DAY_UTIL=0
 SEVEN_DAY_RESET=""
 EXTRA_USAGE_ENABLED="false"
+USAGE_AGE=0
+USAGE_ERROR=""
 
 WEEK_TOKENS=0
 WEEK_MESSAGES=0
@@ -226,10 +228,43 @@ count_profile_tokens() {
         }' > "$out_file" 2>/dev/null || true
 }
 
+# Why did the usage fetch fail? Short stable tokens, the widget maps them to text.
+# Usage: classify_usage_error <credentials_file> <now_epoch> <http_code>
+# An expired OAuth token wins over the HTTP code: the widget only reads
+# `.credentials.json`, it never refreshes it, so a stale login keeps failing until
+# Claude Code runs again - that is the actionable cause, whatever the API answered.
+classify_usage_error() {
+    local creds_file="$1" now_ts="$2" http_code="$3"
+    local expires_ms
+
+    expires_ms=$(jq -r '.claudeAiOauth.expiresAt // 0' "$creds_file" 2>/dev/null | head -1)
+    [[ "$expires_ms" =~ ^[0-9]+$ ]] || expires_ms=0
+    if [ "$expires_ms" -gt 0 ] && [ $(( expires_ms / 1000 )) -le "$now_ts" ]; then
+        echo "token_expired"
+        return
+    fi
+
+    case "$http_code" in
+        000) echo "offline" ;;
+        401|403) echo "unauthorized" ;;
+        429) echo "rate_limited" ;;
+        2*) echo "bad_response" ;;
+        *) echo "http_${http_code}" ;;
+    esac
+}
+
 # --- Per-profile credentials + API usage fetcher ---
 # Usage: fetch_profile_usage <credentials_file> <cache_file> <out_tmpfile>
 # Writes SUBSCRIPTION_TYPE, RATE_LIMIT_TIER, FIVE_HOUR_UTIL, FIVE_HOUR_RESET,
-#        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED to out_tmpfile
+#        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED, USAGE_AGE,
+#        USAGE_ERROR to out_tmpfile
+#
+# USAGE_AGE/USAGE_ERROR describe how trustworthy the rate limit numbers are:
+#   USAGE_AGE=0   USAGE_ERROR=            fetched now, or cache still within TTL
+#   USAGE_AGE=N   USAGE_ERROR=<reason>    fetch failed, serving cache N seconds old
+#   USAGE_AGE=0   USAGE_ERROR=<reason>    fetch failed and no cache, numbers are 0
+# Without them a failed fetch is indistinguishable from a real reading, so the
+# widget shows hours-old numbers as if they were live.
 fetch_profile_usage() {
     local creds_file="$1"
     local cache_file="$2"
@@ -238,10 +273,12 @@ fetch_profile_usage() {
     local sub_type="unknown"
     local tier="unknown"
     local five_util=0 five_reset="" seven_util=0 seven_reset="" extra="false"
+    local usage_age=0 usage_error=""
 
     if [ ! -f "$creds_file" ]; then
-        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
-            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+        usage_error="no_credentials"
+        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_AGE=%s\nUSAGE_ERROR=%s\n' \
+            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" > "$out_file"
         return
     fi
 
@@ -251,8 +288,11 @@ fetch_profile_usage() {
     # Check cache freshness
     local api_resp="{}"
     local use_cache=false cache_matches=false
+    local cache_age=0
+    local now_ts
+    now_ts=$(date +%s)
     if [ -f "$cache_file" ]; then
-        local cache_identity cache_ts now_ts age
+        local cache_identity cache_ts
         cache_identity=$(jq -r '.identity // ""' "$cache_file" 2>/dev/null | head -1)
         [ "$cache_identity" = "$creds_file" ] && cache_matches=true
 
@@ -262,9 +302,9 @@ fetch_profile_usage() {
         # multiline string that would crash the arithmetic below under `set -e`.
         cache_ts=$(jq -r '.cached_at // 0' "$cache_file" 2>/dev/null | head -1)
         [[ "$cache_ts" =~ ^[0-9]+$ ]] || cache_ts=0
-        now_ts=$(date +%s)
-        age=$(( now_ts - cache_ts ))
-        [ "$cache_matches" = true ] && [ "$age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
+        cache_age=$(( now_ts - cache_ts ))
+        [ "$cache_age" -lt 0 ] && cache_age=0
+        [ "$cache_matches" = true ] && [ "$cache_age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
     fi
 
     if [ "$use_cache" = true ]; then
@@ -272,14 +312,27 @@ fetch_profile_usage() {
     else
         local token
         token=$(jq -r '.claudeAiOauth.accessToken // ""' "$creds_file" 2>/dev/null || echo "")
-        if [ -n "$token" ]; then
-            api_resp=$(curl -s --max-time 5 \
+        if [ -z "$token" ]; then
+            usage_error="no_credentials"
+        else
+            # `-w` appends the status on its own line, so the body is everything
+            # before it. Needed to tell "rate limited" from "offline" from a
+            # dead token - all three otherwise look like an empty response.
+            local http_code=000
+            local raw=""
+            raw=$(curl -s -w '\n%{http_code}' --max-time 5 \
                 -H "Authorization: Bearer $token" \
                 -H "Accept: application/json" \
                 -H "Content-Type: application/json" \
                 -H "User-Agent: claude-code/${CLAUDE_VERSION}" \
                 -H "anthropic-beta: oauth-2025-04-20" \
-                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null || echo '{}')
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || raw=""
+            if [ -n "$raw" ]; then
+                http_code="${raw##*$'\n'}"
+                api_resp="${raw%$'\n'*}"
+                [[ "$http_code" =~ ^[0-9]{3}$ ]] || http_code=000
+                [ -n "$api_resp" ] || api_resp="{}"
+            fi
 
             if echo "$api_resp" | jq -e '.five_hour' >/dev/null 2>&1; then
                 # Write atomically: overlapping widget refreshes both target the
@@ -292,8 +345,14 @@ fetch_profile_usage() {
                 else
                     rm -f "$cache_tmp"
                 fi
-            elif [ "$cache_matches" = true ]; then
-                api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
+            else
+                usage_error=$(classify_usage_error "$creds_file" "$now_ts" "$http_code")
+                if [ "$cache_matches" = true ]; then
+                    api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
+                    usage_age="$cache_age"
+                else
+                    api_resp="{}"
+                fi
             fi
         fi
     fi
@@ -304,8 +363,8 @@ fetch_profile_usage() {
     seven_reset=$(echo "$api_resp" | jq -r '.seven_day.resets_at // ""')
     extra=$(echo "$api_resp" | jq -r '.extra_usage.is_enabled // false')
 
-    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
-        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_AGE=%s\nUSAGE_ERROR=%s\n' \
+        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" > "$out_file"
 }
 
 # --- Collect profile list ---
@@ -433,6 +492,8 @@ PROF_SEVEN_DAY_UTIL=""
 PROF_FIVE_HOUR_RESET_LIST=""
 PROF_SEVEN_DAY_RESET_LIST=""
 PROF_EXTRA_USAGE_LIST=""
+PROF_USAGE_AGE_LIST=""
+PROF_USAGE_ERROR_LIST=""
 
 for idx in "${!TMPFILES[@]}"; do
     tmpf="${TMPFILES[$idx]}"
@@ -454,7 +515,7 @@ for idx in "${!TMPFILES[@]}"; do
 
     # Read per-profile usage/subscription
     p_sub="unknown"; p_tier="unknown"
-    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"
+    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"; p_age=0; p_err=""
     if [ -f "$usage_tmpf" ]; then
         p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
         p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
@@ -463,6 +524,9 @@ for idx in "${!TMPFILES[@]}"; do
         p_7u=$(grep "^SEVEN_DAY_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
         p_7r=$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
         p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "false")
+        p_age=$(grep "^USAGE_AGE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+        p_err=$(grep "^USAGE_ERROR=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+        [[ "$p_age" =~ ^[0-9]+$ ]] || p_age=0
     fi
 
     # Default profile drives the top-level aggregate fields
@@ -474,6 +538,8 @@ for idx in "${!TMPFILES[@]}"; do
         SEVEN_DAY_UTIL="$p_7u"
         SEVEN_DAY_RESET="$p_7r"
         EXTRA_USAGE_ENABLED="$p_extra"
+        USAGE_AGE="$p_age"
+        USAGE_ERROR="$p_err"
     fi
 
     # Aggregate token totals
@@ -521,6 +587,8 @@ for idx in "${!TMPFILES[@]}"; do
     PROF_FIVE_HOUR_RESET_LIST="${PROF_FIVE_HOUR_RESET_LIST:+${PROF_FIVE_HOUR_RESET_LIST},}${pname}:${p_5r}"
     PROF_SEVEN_DAY_RESET_LIST="${PROF_SEVEN_DAY_RESET_LIST:+${PROF_SEVEN_DAY_RESET_LIST},}${pname}:${p_7r}"
     PROF_EXTRA_USAGE_LIST="${PROF_EXTRA_USAGE_LIST:+${PROF_EXTRA_USAGE_LIST},}${pname}:${p_extra}"
+    PROF_USAGE_AGE_LIST="${PROF_USAGE_AGE_LIST:+${PROF_USAGE_AGE_LIST},}${pname}:${p_age}"
+    PROF_USAGE_ERROR_LIST="${PROF_USAGE_ERROR_LIST:+${PROF_USAGE_ERROR_LIST},}${pname}:${p_err}"
 
     rm -f "$tmpf" "$usage_tmpf"
 done
@@ -548,6 +616,8 @@ echo "FIVE_HOUR_RESET=${FIVE_HOUR_RESET}"
 echo "SEVEN_DAY_UTIL=${SEVEN_DAY_UTIL}"
 echo "SEVEN_DAY_RESET=${SEVEN_DAY_RESET}"
 echo "EXTRA_USAGE_ENABLED=${EXTRA_USAGE_ENABLED}"
+echo "USAGE_AGE=${USAGE_AGE}"
+echo "USAGE_ERROR=${USAGE_ERROR}"
 echo "WEEK_MESSAGES=${WEEK_MESSAGES}"
 echo "WEEK_SESSIONS=${WEEK_SESSIONS}"
 echo "WEEK_TOKENS=${WEEK_TOKENS}"
@@ -580,3 +650,5 @@ echo "PROFILE_SEVEN_DAY_UTIL=${PROF_SEVEN_DAY_UTIL}"
 echo "PROFILE_FIVE_HOUR_RESET=${PROF_FIVE_HOUR_RESET_LIST}"
 echo "PROFILE_SEVEN_DAY_RESET=${PROF_SEVEN_DAY_RESET_LIST}"
 echo "PROFILE_EXTRA_USAGE=${PROF_EXTRA_USAGE_LIST}"
+echo "PROFILE_USAGE_AGE=${PROF_USAGE_AGE_LIST}"
+echo "PROFILE_USAGE_ERROR=${PROF_USAGE_ERROR_LIST}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -502,8 +502,10 @@ fetch_profile_usage() {
         else
             local http_code=000
             local raw=""
-            local attempt
-            for attempt in 1 2; do
+            # Two passes at most: the second only happens when the first got a 401
+            # and the refresh below produced a different token. The counter itself
+            # is never read, hence `_`.
+            for _ in 1 2; do
                 http_code=000
                 raw=""
                 api_resp="{}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -180,8 +180,19 @@ count_profile_tokens() {
             sess = $7
             total = inp + out + cr + cw
 
-            n_parts = split(model, mparts, "-")
-            family = (n_parts >= 3 && mparts[1] == "claude") ? mparts[2] : model
+            # Model ids arrive decorated depending on how Claude Code reaches the
+            # model: a proxy or Vertex publisher prefix ("cliproxy/claude-opus-5"),
+            # a Bedrock region/vendor prefix and version suffix
+            # ("us.anthropic.claude-sonnet-4-5-20250929-v1:0"), or a Vertex date
+            # suffix ("claude-sonnet-4-5@20250929"). Strip the decoration before
+            # deriving the family, otherwise the same model bills and charts as
+            # several distinct rows and never matches the pricing table.
+            id = model
+            sub("^[^/]+/", "", id)
+            sub("^([a-z]+\\.)+", "", id)
+            sub("[:@].*$", "", id)
+            n_parts = split(id, mparts, "-")
+            family = (n_parts >= 3 && mparts[1] == "claude") ? mparts[2] : id
 
             day[date] += total
             if (date >= week_start) {

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -22,9 +22,9 @@ done
 
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")
 TODAY=$(date +%Y-%m-%d)
-# Calendar week: Monday to Sunday. Drives the Daily Activity strip (its labels
-# are Mo..Su) and is the fallback week for the totals when the API never
-# answered, so there is no rate limit window to align to.
+# Calendar week: Monday to Sunday. The fallback week for every "week" total, and
+# for the Daily Activity strip, when the API never answered and there is no rate
+# limit window to align to.
 DOW=$(date +%u)  # 1=Monday, 7=Sunday
 WEEK_START=$(date -d "$((DOW - 1)) days ago" +%Y-%m-%d)
 # Calendar month: 1st of current month
@@ -65,6 +65,7 @@ WEEK_SESSIONS=0
 MONTH_TOKENS=0
 WEEK_MODELS=""
 DAILY="0,0,0,0,0,0,0"
+TODAY_TOKENS=0
 
 TODAY_COST="0.00"
 WEEK_COST="0.00"
@@ -159,18 +160,23 @@ fi
 #
 # `week_start` is the first day of the window the week totals cover - the rate
 # limit week when the API told us where it starts, the calendar week otherwise.
-# The Daily Activity strip is always the calendar week, because its labels are
-# fixed weekdays, so the two are computed separately on purpose.
+# The Daily Activity strip covers the same seven days, so its bars add up to the
+# week total printed above them, and its labels are derived from this date rather
+# than fixed, because the window can start on any weekday. The one exception is
+# the morning of a reset day: the window's seventh day is yesterday, while the
+# hours since midnight still count toward the window that is about to close, so
+# today rides along in the totals without a bar. TODAY_TOKENS is counted by date
+# for exactly that reason.
 count_profile_tokens() {
     local proj_dir="$1"
     local out_file="$2"
     local week_start="${3:-$WEEK_START}"
 
-    # Day dates for the calendar week (same logic as outer scope)
+    # The seven days of that window, in order, for the Daily Activity strip
     local day_dates=""
     for i in $(seq 0 6); do
         local d
-        d=$(date -d "$WEEK_START + ${i} days" +%Y-%m-%d)
+        d=$(date -d "$week_start + ${i} days" +%Y-%m-%d)
         day_dates="${day_dates:+${day_dates},}${d}"
     done
 
@@ -242,6 +248,10 @@ count_profile_tokens() {
             n = 0; for (s in week_sess) n++
             printf "WEEK_SESSIONS=%d\n", n
             printf "MONTH_TOKENS=%d\n", month_tokens + 0
+            # Today never depends on where it lands in the strip: during the few
+            # hours between midnight and a reset later the same day, today is not
+            # one of the seven window days at all.
+            printf "TODAY_TOKENS=%d\n", (today in day) ? day[today] : 0
 
             daily = ""
             for (i = 1; i <= 7; i++) {
@@ -729,13 +739,14 @@ for pid in "${PIDS[@]}"; do
 done
 
 # --- Read per-profile results and build aggregate + per-profile output vars ---
-WEEK_TOKENS=0; WEEK_MESSAGES=0; WEEK_SESSIONS=0; MONTH_TOKENS=0
+WEEK_TOKENS=0; WEEK_MESSAGES=0; WEEK_SESSIONS=0; MONTH_TOKENS=0; TODAY_TOKENS=0
 DAILY_ARR=(0 0 0 0 0 0 0)
 DAILY_COSTS_ARR=(0.00 0.00 0.00 0.00 0.00 0.00 0.00)
 TODAY_COST="0.00"; WEEK_COST="0.00"; MONTH_COST="0.00"
 
 PROF_WEEK_TOKENS_LIST=""
 PROF_MONTH_TOKENS_LIST=""
+PROF_TODAY_TOKENS_LIST=""
 PROF_WEEK_MESSAGES_LIST=""
 PROF_WEEK_SESSIONS_LIST=""
 PROF_TODAY_COST_LIST=""
@@ -767,6 +778,7 @@ for idx in "${!TMPFILES[@]}"; do
     p_wm=$(grep "^WEEK_MESSAGES=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
     p_ws=$(grep "^WEEK_SESSIONS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
     p_mt=$(grep "^MONTH_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
+    p_tt=$(grep "^TODAY_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
     p_daily=$(grep "^DAILY=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0,0,0,0,0,0,0")
     p_models=$(grep "^WEEK_MODELS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "")
     p_wws=$(grep "^WEEK_WINDOW_START=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "$WEEK_START")
@@ -812,6 +824,7 @@ for idx in "${!TMPFILES[@]}"; do
     WEEK_TOKENS=$(( WEEK_TOKENS + p_wt ))
     WEEK_MESSAGES=$(( WEEK_MESSAGES + p_wm ))
     MONTH_TOKENS=$(( MONTH_TOKENS + p_mt ))
+    TODAY_TOKENS=$(( TODAY_TOKENS + p_tt ))
     WEEK_SESSIONS=$(( WEEK_SESSIONS + p_ws ))
 
     # Aggregate daily arrays (element-wise addition via awk)
@@ -836,6 +849,7 @@ for idx in "${!TMPFILES[@]}"; do
     # Per-profile token lists
     PROF_WEEK_TOKENS_LIST="${PROF_WEEK_TOKENS_LIST:+${PROF_WEEK_TOKENS_LIST},}${pname}:${p_wt}"
     PROF_MONTH_TOKENS_LIST="${PROF_MONTH_TOKENS_LIST:+${PROF_MONTH_TOKENS_LIST},}${pname}:${p_mt}"
+    PROF_TODAY_TOKENS_LIST="${PROF_TODAY_TOKENS_LIST:+${PROF_TODAY_TOKENS_LIST},}${pname}:${p_tt}"
     PROF_WEEK_MESSAGES_LIST="${PROF_WEEK_MESSAGES_LIST:+${PROF_WEEK_MESSAGES_LIST},}${pname}:${p_wm}"
     PROF_WEEK_SESSIONS_LIST="${PROF_WEEK_SESSIONS_LIST:+${PROF_WEEK_SESSIONS_LIST},}${pname}:${p_ws}"
     PROF_TODAY_COST_LIST="${PROF_TODAY_COST_LIST:+${PROF_TODAY_COST_LIST},}${pname}:${p_tc}"
@@ -899,6 +913,7 @@ echo "ALLTIME_MESSAGES=${ALLTIME_MESSAGES}"
 echo "FIRST_SESSION=${FIRST_SESSION}"
 echo "DAILY=${DAILY}"
 echo "MONTH_TOKENS=${MONTH_TOKENS}"
+echo "TODAY_TOKENS=${TODAY_TOKENS}"
 echo "TODAY_COST=${TODAY_COST}"
 echo "WEEK_COST=${WEEK_COST}"
 echo "MONTH_COST=${MONTH_COST}"
@@ -909,6 +924,7 @@ echo "PROFILE_SUBSCRIPTION=${PROF_SUBSCRIPTION_LIST}"
 echo "PROFILE_TIER=${PROF_TIER_LIST}"
 echo "PROFILE_WEEK_TOKENS=${PROF_WEEK_TOKENS_LIST}"
 echo "PROFILE_MONTH_TOKENS=${PROF_MONTH_TOKENS_LIST}"
+echo "PROFILE_TODAY_TOKENS=${PROF_TODAY_TOKENS_LIST}"
 echo "PROFILE_WEEK_MESSAGES=${PROF_WEEK_MESSAGES_LIST}"
 echo "PROFILE_WEEK_SESSIONS=${PROF_WEEK_SESSIONS_LIST}"
 echo "PROFILE_TODAY_COST=${PROF_TODAY_COST_LIST}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -22,11 +22,29 @@ done
 
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")
 TODAY=$(date +%Y-%m-%d)
-# Calendar week: Monday to Sunday
+# Calendar week: Monday to Sunday. Drives the Daily Activity strip (its labels
+# are Mo..Su) and is the fallback week for the totals when the API never
+# answered, so there is no rate limit window to align to.
 DOW=$(date +%u)  # 1=Monday, 7=Sunday
 WEEK_START=$(date -d "$((DOW - 1)) days ago" +%Y-%m-%d)
 # Calendar month: 1st of current month
 MONTH_START=$(date +%Y-%m-01)
+
+# The rate limit week does not start on Monday: `seven_day.resets_at` lands on a
+# fixed weekday (Thursday here), so the window that the 7-day ring measures is
+# the seven days before it. Totals labelled "week" have to use that window, or
+# the popout puts session counts, token totals and the model card from a Monday
+# week next to a ring from a Thursday one - on a Monday that reads as if the
+# whole 71% came from the one model used today.
+# Bucketing is date-granular everywhere in this script, so take the local date
+# of the boundary and accept that a few hours of its first day ride along.
+limit_week_start() {
+    local resets_at="$1" ws
+    [ -n "$resets_at" ] || return 1
+    ws=$(date -d "$resets_at - 7 days" +%Y-%m-%d 2>/dev/null) || return 1
+    [[ "$ws" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+    printf '%s' "$ws"
+}
 
 # Defaults
 SUBSCRIPTION_TYPE="unknown"
@@ -38,6 +56,8 @@ SEVEN_DAY_RESET=""
 EXTRA_USAGE_ENABLED="false"
 USAGE_AGE=0
 USAGE_ERROR=""
+WEEKLY_SCOPED=""
+WEEK_WINDOW_START="$WEEK_START"
 
 WEEK_TOKENS=0
 WEEK_MESSAGES=0
@@ -134,11 +154,17 @@ else
 fi
 
 # --- Per-profile token counting ---
-# Usage: count_profile_tokens <projects_dir> <tmpfile>
+# Usage: count_profile_tokens <projects_dir> <tmpfile> [week_start]
 # Writes WEEK_TOKENS=N, WEEK_MESSAGES=N, ... to tmpfile
+#
+# `week_start` is the first day of the window the week totals cover - the rate
+# limit week when the API told us where it starts, the calendar week otherwise.
+# The Daily Activity strip is always the calendar week, because its labels are
+# fixed weekdays, so the two are computed separately on purpose.
 count_profile_tokens() {
     local proj_dir="$1"
     local out_file="$2"
+    local week_start="${3:-$WEEK_START}"
 
     # Day dates for the calendar week (same logic as outer scope)
     local day_dates=""
@@ -158,7 +184,7 @@ count_profile_tokens() {
             | (.timestamp // "") as $ts
             | ('"$JQ_DATE_EXPR"') as $d
             | "\($d) \(.message.model // "unknown") \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0) \(.message.usage.cache_read_input_tokens // 0) \(.message.usage.cache_creation_input_tokens // 0) \(.sessionId // "unknown")"' \
-        | awk -v week_start="$WEEK_START" -v month_start="$MONTH_START" -v today="$TODAY" -v day_dates="$day_dates" -v pricing="$PRICING_AWK" '
+        | awk -v week_start="$week_start" -v month_start="$MONTH_START" -v today="$TODAY" -v day_dates="$day_dates" -v pricing="$PRICING_AWK" '
         BEGIN {
             split(day_dates, dates, ",")
             has_pricing = 0
@@ -423,10 +449,19 @@ classify_usage_error() {
 }
 
 # --- Per-profile credentials + API usage fetcher ---
+# Every exit path emits the same field set, so one emitter owns the format and
+# the field order. Arguments, in order: out_file, subscription type, rate limit
+# tier, 5h utilization, 5h reset, 7d utilization, 7d reset, extra usage flag,
+# usage age, usage error, scoped weekly limits.
+write_usage_fields() {
+    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_AGE=%s\nUSAGE_ERROR=%s\nWEEKLY_SCOPED=%s\n' \
+        "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}" > "$1"
+}
+
 # Usage: fetch_profile_usage <credentials_file> <cache_file> <out_tmpfile>
 # Writes SUBSCRIPTION_TYPE, RATE_LIMIT_TIER, FIVE_HOUR_UTIL, FIVE_HOUR_RESET,
 #        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED, USAGE_AGE,
-#        USAGE_ERROR to out_tmpfile
+#        USAGE_ERROR, WEEKLY_SCOPED to out_tmpfile
 #
 # USAGE_AGE/USAGE_ERROR describe how trustworthy the rate limit numbers are:
 #   USAGE_AGE=0   USAGE_ERROR=            fetched now, or cache still within TTL
@@ -442,12 +477,12 @@ fetch_profile_usage() {
     local sub_type="unknown"
     local tier="unknown"
     local five_util=0 five_reset="" seven_util=0 seven_reset="" extra="false"
-    local usage_age=0 usage_error=""
+    local usage_age=0 usage_error="" scoped=""
 
     if [ ! -f "$creds_file" ]; then
         usage_error="no_credentials"
-        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_AGE=%s\nUSAGE_ERROR=%s\n' \
-            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" > "$out_file"
+        write_usage_fields "$out_file" "$sub_type" "$tier" "$five_util" "$five_reset" \
+            "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" "$scoped"
         return
     fi
 
@@ -568,9 +603,20 @@ fetch_profile_usage() {
     seven_util=$(echo "$api_resp" | jq -r '.seven_day.utilization // 0')
     seven_reset=$(echo "$api_resp" | jq -r '.seven_day.resets_at // ""')
     extra=$(echo "$api_resp" | jq -r '.extra_usage.is_enabled // false')
+    # `.limits` carries the rows claude.ai lists under "Weekly limits": the
+    # all-models cap, plus a scoped one per model that has its own cap (Fable
+    # today). `seven_day` is only the all-models row, so without these the
+    # widget cannot say a model is near its own limit while the total is fine.
+    scoped=$(echo "$api_resp" | jq -r '
+        [ (.limits // [])[]
+          | select(.kind == "weekly_scoped")
+          | ((.scope.model.display_name // "") | gsub("[,:|]"; "")) as $n
+          | select($n != "")
+          | "\($n):\(.percent // 0)" ]
+        | join(",")' 2>/dev/null || echo "")
 
-    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_AGE=%s\nUSAGE_ERROR=%s\n' \
-        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" > "$out_file"
+    write_usage_fields "$out_file" "$sub_type" "$tier" "$five_util" "$five_reset" \
+        "$seven_util" "$seven_reset" "$extra" "$usage_age" "$usage_error" "$scoped"
 }
 
 # --- Collect profile list ---
@@ -665,8 +711,15 @@ for idx in "${!PROFILE_DIRS[@]}"; do
     fi
 
     (
-        count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf"
+        # Usage first: its `seven_day.resets_at` decides which seven days the
+        # week totals below have to cover. Both still run in parallel across
+        # profiles, and the fetch is cache-backed, so this costs nothing.
         fetch_profile_usage "${PROFILE_CREDS[$idx]}" "$prof_cache" "$usage_tmpf"
+        prof_week_start=$(limit_week_start \
+            "$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2-)" \
+            || echo "$WEEK_START")
+        count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf" "$prof_week_start"
+        echo "WEEK_WINDOW_START=${prof_week_start}" >> "$tmpf"
     ) &
     PIDS+=("$!")
 done
@@ -700,6 +753,8 @@ PROF_SEVEN_DAY_RESET_LIST=""
 PROF_EXTRA_USAGE_LIST=""
 PROF_USAGE_AGE_LIST=""
 PROF_USAGE_ERROR_LIST=""
+PROF_WEEKLY_SCOPED_LIST=""
+PROF_WEEK_WINDOW_LIST=""
 
 for idx in "${!TMPFILES[@]}"; do
     tmpf="${TMPFILES[$idx]}"
@@ -714,6 +769,8 @@ for idx in "${!TMPFILES[@]}"; do
     p_mt=$(grep "^MONTH_TOKENS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
     p_daily=$(grep "^DAILY=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0,0,0,0,0,0,0")
     p_models=$(grep "^WEEK_MODELS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+    p_wws=$(grep "^WEEK_WINDOW_START=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "$WEEK_START")
+    [ -n "$p_wws" ] || p_wws="$WEEK_START"
     p_dc=$(grep "^DAILY_COSTS=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00,0.00,0.00,0.00,0.00,0.00,0.00")
     p_tc=$(grep "^TODAY_COST=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00")
     p_wc=$(grep "^WEEK_COST=" "$tmpf" 2>/dev/null | cut -d= -f2- || echo "0.00")
@@ -721,7 +778,7 @@ for idx in "${!TMPFILES[@]}"; do
 
     # Read per-profile usage/subscription
     p_sub="unknown"; p_tier="unknown"
-    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"; p_age=0; p_err=""
+    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"; p_age=0; p_err=""; p_scoped=""
     if [ -f "$usage_tmpf" ]; then
         p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
         p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
@@ -732,6 +789,7 @@ for idx in "${!TMPFILES[@]}"; do
         p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "false")
         p_age=$(grep "^USAGE_AGE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
         p_err=$(grep "^USAGE_ERROR=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
+        p_scoped=$(grep "^WEEKLY_SCOPED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
         [[ "$p_age" =~ ^[0-9]+$ ]] || p_age=0
     fi
 
@@ -746,6 +804,8 @@ for idx in "${!TMPFILES[@]}"; do
         EXTRA_USAGE_ENABLED="$p_extra"
         USAGE_AGE="$p_age"
         USAGE_ERROR="$p_err"
+        WEEKLY_SCOPED="$p_scoped"
+        WEEK_WINDOW_START="$p_wws"
     fi
 
     # Aggregate token totals
@@ -795,6 +855,10 @@ for idx in "${!TMPFILES[@]}"; do
     PROF_EXTRA_USAGE_LIST="${PROF_EXTRA_USAGE_LIST:+${PROF_EXTRA_USAGE_LIST},}${pname}:${p_extra}"
     PROF_USAGE_AGE_LIST="${PROF_USAGE_AGE_LIST:+${PROF_USAGE_AGE_LIST},}${pname}:${p_age}"
     PROF_USAGE_ERROR_LIST="${PROF_USAGE_ERROR_LIST:+${PROF_USAGE_ERROR_LIST},}${pname}:${p_err}"
+    # Scoped limits hold `Model:percent` pairs joined by `,`, so profiles are
+    # separated by `|` here the same way PROFILE_WEEK_MODELS does it.
+    PROF_WEEKLY_SCOPED_LIST="${PROF_WEEKLY_SCOPED_LIST:+${PROF_WEEKLY_SCOPED_LIST}|}${pname}:${p_scoped}"
+    PROF_WEEK_WINDOW_LIST="${PROF_WEEK_WINDOW_LIST:+${PROF_WEEK_WINDOW_LIST},}${pname}:${p_wws}"
 
     rm -f "$tmpf" "$usage_tmpf"
 done
@@ -824,6 +888,8 @@ echo "SEVEN_DAY_RESET=${SEVEN_DAY_RESET}"
 echo "EXTRA_USAGE_ENABLED=${EXTRA_USAGE_ENABLED}"
 echo "USAGE_AGE=${USAGE_AGE}"
 echo "USAGE_ERROR=${USAGE_ERROR}"
+echo "WEEKLY_SCOPED=${WEEKLY_SCOPED}"
+echo "WEEK_WINDOW_START=${WEEK_WINDOW_START}"
 echo "WEEK_MESSAGES=${WEEK_MESSAGES}"
 echo "WEEK_SESSIONS=${WEEK_SESSIONS}"
 echo "WEEK_TOKENS=${WEEK_TOKENS}"
@@ -858,3 +924,5 @@ echo "PROFILE_SEVEN_DAY_RESET=${PROF_SEVEN_DAY_RESET_LIST}"
 echo "PROFILE_EXTRA_USAGE=${PROF_EXTRA_USAGE_LIST}"
 echo "PROFILE_USAGE_AGE=${PROF_USAGE_AGE_LIST}"
 echo "PROFILE_USAGE_ERROR=${PROF_USAGE_ERROR_LIST}"
+echo "PROFILE_WEEKLY_SCOPED=${PROF_WEEKLY_SCOPED_LIST}"
+echo "PROFILE_WEEK_WINDOW_START=${PROF_WEEK_WINDOW_LIST}"

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -16,8 +16,16 @@ LITELLM_URL="https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices
 # the cache to age out. Profile arguments are `name=path`, so a bare flag can
 # never collide with one.
 FORCE_FETCH=false
+# Claude Code is not the only client that spends this subscription: a bridge like
+# cliproxyapi lets other agent harnesses (pi, and anything else pointed at it)
+# talk to the same account, and those calls never touch ~/.claude/projects. With
+# only Claude Code transcripts counted, a day spent entirely in such a client
+# reads as "today 0 tokens" under a 5h ring that says 16% used. So their
+# transcripts are counted too, unless `--no-bridged` asks us not to.
+COUNT_BRIDGED=true
 for arg in "$@"; do
     [ "$arg" = "--force" ] && FORCE_FETCH=true
+    [ "$arg" = "--no-bridged" ] && COUNT_BRIDGED=false
 done
 
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")
@@ -154,8 +162,81 @@ else
     JQ_DATE_EXPR='(if ($ts | length) >= 10 then $ts[:10] else "1970-01-01" end)'
 fi
 
+# --- Transcript record streams ---
+# Every producer below emits the same eight-field record, and the awk pass in
+# count_profile_tokens is the only thing that knows what to do with it:
+#
+#   <local date> <model> <input> <output> <cache read> <cache write> <session> <cost>
+#
+# `cost` is -1 when the transcript does not price the call itself, meaning "price
+# this from the litellm table". Claude Code transcripts always say -1; harnesses
+# that record their own cost (pi does) hand it over, which is the only way to
+# cost a model the pricing table has never heard of.
+
+# emit_claude_records <projects_dir>
+emit_claude_records() {
+    local proj_dir="$1"
+
+    find "$proj_dir" -name "*.jsonl" -mtime -31 -exec cat {} + 2>/dev/null \
+        | jq -r -R 'fromjson? | select(.type == "assistant")
+            # Bucket by LOCAL calendar date, not UTC. Timestamps are ISO-8601 UTC
+            # (e.g. 2026-06-30T00:10:33Z); convert to the local date so the daily
+            # boundaries match TODAY/WEEK_START/MONTH_START (computed via local `date`)
+            # and the widget'"'"'s todayIndex. Falls back to the raw UTC slice if parsing
+            # fails or jq lacks strflocaltime (see JQ_DATE_EXPR probe above).
+            | (.timestamp // "") as $ts
+            | ('"$JQ_DATE_EXPR"') as $d
+            | "\($d) \(.message.model // "unknown") \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0) \(.message.usage.cache_read_input_tokens // 0) \(.message.usage.cache_creation_input_tokens // 0) \(.sessionId // "unknown") -1"'
+}
+
+# Where the bridged harnesses keep their transcripts. pi is the one that exists
+# today: `~/.pi/agent/sessions/<cwd>/<stamp>_<id>.jsonl`, plus one such tree per
+# named profile. PI_CONFIG_DIR moves the lot, so honour it.
+BRIDGED_ROOTS=()
+if [ "$COUNT_BRIDGED" = true ]; then
+    pi_home="${PI_CONFIG_DIR:-${HOME}/.pi}"
+    if [ -d "$pi_home" ]; then
+        for bridged_dir in "${pi_home}/agent/sessions" "${pi_home}"/profiles/*/sessions; do
+            [ -d "$bridged_dir" ] && BRIDGED_ROOTS+=("$bridged_dir")
+        done
+    fi
+    unset pi_home bridged_dir
+fi
+
+# emit_bridged_records
+# Only Claude models count: the same harness also drives Gemini and GPT, and
+# those tokens are nobody's Claude subscription. One jq per file because pi keeps
+# the session id in the filename (`<stamp>_<uuid>.jsonl`) and not in the records;
+# ids are prefixed so they can never collide with a Claude Code session uuid.
+emit_bridged_records() {
+    local root file sid
+
+    [ "${#BRIDGED_ROOTS[@]}" -gt 0 ] || return 0
+
+    for root in "${BRIDGED_ROOTS[@]}"; do
+        while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            sid="${file##*/}"
+            sid="${sid%.jsonl}"
+            sid="bridged:${sid##*_}"
+            jq -r -R --arg sid "$sid" 'fromjson? | select(.type == "message")
+                # The envelope timestamp is the one always present; the message
+                # carries its own copy for most record kinds.
+                | ((.timestamp // .message.timestamp // "")) as $ts
+                | ('"$JQ_DATE_EXPR"') as $d
+                | (.message // {})
+                | select(.role == "assistant")
+                | (.model // "unknown") as $m
+                | select($m | test("claude"; "i"))
+                | (.usage // {}) as $u
+                | "\($d) \($m) \($u.input // 0) \($u.output // 0) \($u.cacheRead // 0) \($u.cacheWrite // 0) \($sid) \($u.cost.total // -1)"' \
+                "$file" 2>/dev/null || true
+        done < <(find "$root" -name "*.jsonl" -mtime -31 2>/dev/null)
+    done
+}
+
 # --- Per-profile token counting ---
-# Usage: count_profile_tokens <projects_dir> <tmpfile> [week_start]
+# Usage: count_profile_tokens <projects_dir> <tmpfile> [week_start] [count_bridged]
 # Writes WEEK_TOKENS=N, WEEK_MESSAGES=N, ... to tmpfile
 #
 # `week_start` is the first day of the window the week totals cover - the rate
@@ -171,6 +252,9 @@ count_profile_tokens() {
     local proj_dir="$1"
     local out_file="$2"
     local week_start="${3:-$WEEK_START}"
+    # Bridged transcripts carry no profile of their own, so they belong to the
+    # login whose rate limit rings the popout shows: the default profile.
+    local count_bridged="${4:-false}"
 
     # The seven days of that window, in order, for the Daily Activity strip
     local day_dates=""
@@ -180,16 +264,10 @@ count_profile_tokens() {
         day_dates="${day_dates:+${day_dates},}${d}"
     done
 
-    find "$proj_dir" -name "*.jsonl" -mtime -31 -exec cat {} + 2>/dev/null \
-        | jq -r -R 'fromjson? | select(.type == "assistant")
-            # Bucket by LOCAL calendar date, not UTC. Timestamps are ISO-8601 UTC
-            # (e.g. 2026-06-30T00:10:33Z); convert to the local date so the daily
-            # boundaries match TODAY/WEEK_START/MONTH_START (computed via local `date`)
-            # and the widget'"'"'s todayIndex. Falls back to the raw UTC slice if parsing
-            # fails or jq lacks strflocaltime (see JQ_DATE_EXPR probe above).
-            | (.timestamp // "") as $ts
-            | ('"$JQ_DATE_EXPR"') as $d
-            | "\($d) \(.message.model // "unknown") \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0) \(.message.usage.cache_read_input_tokens // 0) \(.message.usage.cache_creation_input_tokens // 0) \(.sessionId // "unknown")"' \
+    {
+        emit_claude_records "$proj_dir"
+        [ "$count_bridged" = true ] && emit_bridged_records
+    } \
         | awk -v week_start="$week_start" -v month_start="$MONTH_START" -v today="$TODAY" -v day_dates="$day_dates" -v pricing="$PRICING_AWK" '
         BEGIN {
             split(day_dates, dates, ",")
@@ -210,6 +288,7 @@ count_profile_tokens() {
             date = $1; model = $2
             inp = $3 + 0; out = $4 + 0; cr = $5 + 0; cw = $6 + 0
             sess = $7
+            rec_cost = ($8 == "") ? -1 : $8 + 0
             total = inp + out + cr + cw
 
             # Model ids arrive decorated depending on how Claude Code reaches the
@@ -235,8 +314,17 @@ count_profile_tokens() {
             }
             if (date >= month_start) month_tokens += total
 
-            if (has_pricing && (family in price_in)) {
+            # A cost the transcript computed itself wins: it priced the exact
+            # model that answered, including ones the litellm table has never
+            # heard of, where the table lookup below finds nothing and the call
+            # would otherwise cost zero.
+            cost = -1
+            if (rec_cost >= 0) {
+                cost = rec_cost
+            } else if (has_pricing && (family in price_in)) {
                 cost = inp * price_in[family] + out * price_out[family] + cr * price_cr[family] + cw * price_cw[family]
+            }
+            if (cost >= 0) {
                 day_cost[date] += cost
                 if (date >= week_start) week_cost += cost
                 if (date >= month_start) month_cost += cost
@@ -728,7 +816,9 @@ for idx in "${!PROFILE_DIRS[@]}"; do
         prof_week_start=$(limit_week_start \
             "$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2-)" \
             || echo "$WEEK_START")
-        count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf" "$prof_week_start"
+        prof_bridged=false
+        [ "$pname" = "default" ] && prof_bridged="$COUNT_BRIDGED"
+        count_profile_tokens "${PROFILE_DIRS[$idx]}" "$tmpf" "$prof_week_start" "$prof_bridged"
         echo "WEEK_WINDOW_START=${prof_week_start}" >> "$tmpf"
     ) &
     PIDS+=("$!")

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -11,6 +11,15 @@ USAGE_CACHE="${CLAUDE_DIR}/usage-cache.json"
 USAGE_CACHE_TTL=90  # seconds, below the 2 min minimum refresh interval
 LITELLM_URL="https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
 
+# `--force` (manual refresh from the popout) skips the usage cache TTL, so a
+# user who just fixed a dead login sees it immediately instead of waiting for
+# the cache to age out. Profile arguments are `name=path`, so a bare flag can
+# never collide with one.
+FORCE_FETCH=false
+for arg in "$@"; do
+    [ "$arg" = "--force" ] && FORCE_FETCH=true
+done
+
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")
 TODAY=$(date +%Y-%m-%d)
 # Calendar week: Monday to Sunday
@@ -304,7 +313,9 @@ fetch_profile_usage() {
         [[ "$cache_ts" =~ ^[0-9]+$ ]] || cache_ts=0
         cache_age=$(( now_ts - cache_ts ))
         [ "$cache_age" -lt 0 ] && cache_age=0
-        [ "$cache_matches" = true ] && [ "$cache_age" -lt "$USAGE_CACHE_TTL" ] && use_cache=true
+        if [ "$FORCE_FETCH" != true ] && [ "$cache_matches" = true ] && [ "$cache_age" -lt "$USAGE_CACHE_TTL" ]; then
+            use_cache=true
+        fi
     fi
 
     if [ "$use_cache" = true ]; then

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -1132,12 +1132,19 @@ assert_eq "$(usage_field "$OUT32" WEEK_SESSIONS)" "2" \
     "sessions follow the same window"
 assert_eq "$(usage_field "$OUT32" WEEK_MESSAGES)" "2" \
     "messages follow the same window"
-# The strip below the rings is labelled Mo..Su, so it stays on calendar dates
-# even though the totals above it do not.
-TODAY_IDX32=$(( $(date +%u) - 1 ))
+# The strip covers the same seven days as the totals above it, so a bar's
+# position is an offset from the window start, not a weekday.
 DAILY32=$(usage_field "$OUT32" DAILY)
-assert_eq "$(echo "$DAILY32" | cut -d, -f$(( TODAY_IDX32 + 1 )))" "4000" \
-    "the daily strip still buckets by calendar day"
+assert_eq "$(echo "$DAILY32" | cut -d, -f1)" "2000" \
+    "the strip starts on the window's first day"
+assert_eq "$(echo "$DAILY32" | cut -d, -f6)" "4000" \
+    "today sits five days into a window that opened five days ago"
+assert_eq "$(echo "$DAILY32" | awk -F, '{ s = 0; for (i = 1; i <= NF; i++) s += $i; print s }')" "6000" \
+    "the bars add up to the week total"
+assert_eq "$(usage_field "$OUT32" TODAY_TOKENS)" "4000" \
+    "today is reported on its own, not read out of the strip"
+assert_eq "$(echo "$DAILY32" | cut -d, -f7)" "0" \
+    "the day after tomorrow is empty, not the day before the window"
 assert_eq "$(usage_field "$OUT32" WEEKLY_SCOPED)" "Fable 1Mx:6" \
     "a scoped weekly limit is reported per model, delimiters stripped"
 
@@ -1159,6 +1166,48 @@ OUT32C=$(run_script "$ENV32C")
 unset MOCK_CURL_CODE MOCK_CURL_BODY
 assert_eq "$(usage_field "$OUT32C" WEEKLY_SCOPED)" "" \
     "a scoped row without a model name is dropped"
+
+# ============================================================
+echo ""
+echo "=== Test 33: on a reset day today rides along outside the strip ==="
+# ============================================================
+# When the reset lands later today the window's seven days end yesterday, but
+# the hours since midnight still count toward the window that is closing. The
+# strip has no column for today, so TODAY_TOKENS has to be counted by date -
+# reading the last bar would report yesterday's usage as today's.
+ENV33=$(setup_env "test33")
+write_creds "$ENV33" "$FUTURE_MS"
+
+# Local noon today, expressed in UTC: the date of the boundary is today whatever
+# the current hour is, so the window always starts seven days back.
+RESET33=$(date -u -d "today 12:00" +%Y-%m-%dT%H:%M:%S+00:00)
+WINDOW33=$(date -d "-7 days" +%Y-%m-%d)
+YESTERDAY33=$(date -d "-1 day" +%Y-%m-%d)
+
+{
+    make_jsonl_line "$WINDOW33" "claude-opus-4" 1000 0 0 0 "sess-first"
+    make_jsonl_line "$YESTERDAY33" "claude-opus-4" 2000 0 0 0 "sess-last"
+    make_jsonl_line "$TODAY" "claude-opus-4" 500 0 0 0 "sess-today"
+} > "$ENV33/.claude/projects/test-project/test.jsonl"
+
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY="{\"five_hour\":{\"utilization\":10,\"resets_at\":\"2099-01-01T00:00:00Z\"},\"seven_day\":{\"utilization\":80,\"resets_at\":\"$RESET33\"},\"extra_usage\":{\"is_enabled\":false}}"
+OUT33=$(run_script "$ENV33")
+unset MOCK_CURL_CODE MOCK_CURL_BODY
+
+assert_eq "$(usage_field "$OUT33" WEEK_WINDOW_START)" "$WINDOW33" \
+    "a reset later today opens the window seven days back"
+DAILY33=$(usage_field "$OUT33" DAILY)
+assert_eq "$(echo "$DAILY33" | cut -d, -f1)" "1000" \
+    "the window's first day is the first bar"
+assert_eq "$(echo "$DAILY33" | cut -d, -f7)" "2000" \
+    "yesterday is the last bar, today has none"
+assert_eq "$(usage_field "$OUT33" TODAY_TOKENS)" "500" \
+    "today is still counted, from its date"
+assert_eq "$(usage_field "$OUT33" WEEK_TOKENS)" "3500" \
+    "the closing window keeps today's hours in its total"
+assert_eq "$(usage_field "$OUT33" PROFILE_TODAY_TOKENS)" "default:500" \
+    "today is reported per profile too"
 # ============================================================
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -823,5 +823,26 @@ assert_match "$(usage_field "$OUT28C" PROFILE_USAGE_AGE)" "default:[0-9]+" \
 
 # ============================================================
 echo ""
+echo "=== Test 29: --force bypasses the usage cache ==="
+# ============================================================
+# The popout refresh button passes `--force`. With a fresh cache on disk saying
+# 42 and the API saying 7, a plain run serves the cache and a forced run refetches
+# - otherwise the manual refresh would replay the numbers the user clicked to
+# get rid of. The flag must also never be mistaken for a `name=path` profile.
+ENV29=$(setup_env "test29")
+write_creds "$ENV29" "$FUTURE_MS"
+write_usage_cache "$ENV29" "$(date +%s)" 42
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY='{"five_hour":{"utilization":7,"resets_at":"2099-01-01T00:00:00Z"},"seven_day":{"utilization":2,"resets_at":"2099-01-07T00:00:00Z"},"extra_usage":{"is_enabled":false}}'
+
+assert_eq "$(usage_field "$(run_script "$ENV29")" FIVE_HOUR_UTIL)" "42" \
+    "fresh cache serves the cached number"
+OUT29=$(run_script "$ENV29" --force)
+assert_eq "$(usage_field "$OUT29" FIVE_HOUR_UTIL)" "7" "--force refetches past a fresh cache"
+assert_eq "$(usage_field "$OUT29" PROFILES)" "default" "--force is not registered as a profile"
+unset MOCK_CURL_CODE MOCK_CURL_BODY
+
+# ============================================================
+echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -842,6 +842,44 @@ assert_eq "$(usage_field "$OUT29" FIVE_HOUR_UTIL)" "7" "--force refetches past a
 assert_eq "$(usage_field "$OUT29" PROFILES)" "default" "--force is not registered as a profile"
 unset MOCK_CURL_CODE MOCK_CURL_BODY
 
+echo "=== Test 31: decorated model ids fold into their family ==="
+# ============================================================
+# Claude Code reports whatever id the backend uses: Bedrock adds a region and a
+# version (`us.anthropic.…-v1:0`), Vertex a publisher path or an `@date`, a proxy
+# its own prefix. Without normalisation each spelling becomes its own row in the
+# model card and misses the pricing table, so one model reads as four unpriced
+# ones.
+ENV31=$(setup_env "test31")
+cat > "$ENV31/.claude/pricing-cache.json" << 'PRICE31EOF'
+{
+    "updated": "2099-12-31",
+    "models": {
+        "sonnet": {"input": 0.000003, "output": 0.000015, "cache_read": 0.0000003, "cache_write": 0.00000375},
+        "opus": {"input": 0.000015, "output": 0.000075, "cache_read": 0.0000015, "cache_write": 0.00001875}
+    }
+}
+PRICE31EOF
+
+{
+    make_jsonl_line "$TODAY" "us.anthropic.claude-sonnet-4-5-20250929-v1:0" 1000000 0 0 0 "sess-bedrock"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-5@20250929" 1000000 0 0 0 "sess-vertex"
+    make_jsonl_line "$TODAY" "cliproxy/claude-opus-5" 1000000 0 0 0 "sess-proxy"
+    make_jsonl_line "$TODAY" "claude-sonnet-4-20250514" 1000000 0 0 0 "sess-plain"
+    make_jsonl_line "$TODAY" "openrouter/qwen3-coder" 1000000 0 0 0 "sess-other"
+} > "$ENV31/.claude/projects/test-project/test.jsonl"
+
+OUT31=$(run_script "$ENV31")
+MODELS31=$(usage_field "$OUT31" WEEK_MODELS)
+assert_match "$MODELS31" "(^|,)sonnet=3000000(,|$)" "bedrock, vertex and plain ids all count as sonnet"
+assert_match "$MODELS31" "(^|,)opus=1000000(,|$)" "a proxy-prefixed id counts as opus"
+assert_match "$MODELS31" "(^|,)qwen3-coder=1000000(,|$)" "a non-Claude id keeps its name without the proxy prefix"
+if echo "$MODELS31" | grep -qE 'cliproxy|openrouter|anthropic|v1|@'; then
+    fail "decorated ids leaked into the model card ($MODELS31)"
+else
+    pass "no decorated id survives in the model card"
+fi
+assert_eq "$(usage_field "$OUT31" TODAY_COST)" "24.00" "every decorated id matched the pricing table"
+
 # ============================================================
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -1210,5 +1210,73 @@ assert_eq "$(usage_field "$OUT33" PROFILE_TODAY_TOKENS)" "default:500" \
     "today is reported per profile too"
 # ============================================================
 echo ""
+echo "=== Test 34: bridged clients on the same subscription are counted ==="
+# ============================================================
+# Anything pointed at a bridge (cliproxyapi and friends) spends this very
+# subscription while writing its transcripts somewhere else entirely. Those
+# tokens are already inside the rate limit rings, so leaving them out is what
+# reads as broken: "today 0 tokens" under a ring that says 16% used.
+ENV34=$(setup_env "test34")
+
+# pi's layout: ~/.pi/agent/sessions/<cwd>/<stamp>_<uuid>.jsonl, plus one such
+# tree per named profile. Session ids live in the filename, not the records.
+mkdir -p "$ENV34/.pi/agent/sessions/--home-user--" "$ENV34/.pi/profiles/work/sessions/--home-user-src--"
+
+# Usage: make_bridged_line <date> <model> <input> <output> <cacheRead> <cacheWrite> [cost]
+make_bridged_line() {
+    local date="$1" model="$2" inp="$3" out="$4" cr="$5" cw="$6" cost="${7:-}"
+    local cost_json=""
+    [ -n "$cost" ] && cost_json=",\"cost\":{\"total\":$cost}"
+    printf '{"type":"message","timestamp":"%sT12:00:00Z","message":{"role":"assistant","model":"%s","usage":{"input":%d,"output":%d,"cacheRead":%d,"cacheWrite":%d%s}}}\n' \
+        "$date" "$model" "$inp" "$out" "$cr" "$cw" "$cost_json"
+}
+
+make_jsonl_line "$TODAY" "claude-opus-4" 100 0 0 0 "cc-session" \
+    > "$ENV34/.claude/projects/test-project/test.jsonl"
+{
+    make_bridged_line "$TODAY" "claude-opus-4" 10 20 30 40 "1.50"
+    # Same account, other harness, a model no pricing table knows: without the
+    # transcript's own cost this call would be free.
+    make_bridged_line "$TODAY" "claude-fable-5" 1 2 3 4 "0.25"
+    # Not Claude, not this subscription.
+    make_bridged_line "$TODAY" "gemini-3-pro" 5000 5000 0 0 "9.99"
+    # User turns and tool results are not billable assistant answers.
+    printf '{"type":"message","timestamp":"%sT12:00:00Z","message":{"role":"user","content":"hi"}}\n' "$TODAY"
+} > "$ENV34/.pi/agent/sessions/--home-user--/2026-08-17T08-00-00-000Z_aaaa-1111.jsonl"
+make_bridged_line "$TODAY" "claude-sonnet-4-5" 1000 0 0 0 "2.00" \
+    > "$ENV34/.pi/profiles/work/sessions/--home-user-src--/2026-08-17T09-00-00-000Z_bbbb-2222.jsonl"
+
+OUT34=$(run_script "$ENV34")
+
+assert_eq "$(usage_field "$OUT34" TODAY_TOKENS)" "1210" \
+    "bridged Claude tokens land in today's total, other vendors do not"
+assert_eq "$(usage_field "$OUT34" WEEK_SESSIONS)" "3" \
+    "each bridged transcript file counts as its own session"
+assert_eq "$(usage_field "$OUT34" WEEK_MESSAGES)" "4" \
+    "only assistant answers are counted as messages"
+assert_match "$(usage_field "$OUT34" WEEK_MODELS)" "fable=10" \
+    "a bridged model unknown to the pricing table still gets its own row"
+assert_eq "$(usage_field "$OUT34" TODAY_COST)" "3.75" \
+    "the cost the transcript computed itself is used, tables cannot price fable"
+assert_eq "$(usage_field "$OUT34" PROFILE_TODAY_TOKENS)" "default:1210" \
+    "bridged usage belongs to the login whose rings the popout shows"
+
+# The opt-out has to reproduce the old, Claude-Code-only numbers exactly.
+OUT34B=$(run_script "$ENV34" --no-bridged)
+assert_eq "$(usage_field "$OUT34B" TODAY_TOKENS)" "100" \
+    "--no-bridged counts Claude Code transcripts only"
+assert_eq "$(usage_field "$OUT34B" WEEK_SESSIONS)" "1" \
+    "--no-bridged leaves bridged sessions out of the session count"
+
+# A machine that never ran another client must behave exactly as before.
+ENV34C=$(setup_env "test34c")
+make_jsonl_line "$TODAY" "claude-opus-4" 100 0 0 0 "cc-session" \
+    > "$ENV34C/.claude/projects/test-project/test.jsonl"
+OUT34C=$(run_script "$ENV34C")
+assert_eq "$(usage_field "$OUT34C" TODAY_TOKENS)" "100" \
+    "no bridged transcripts anywhere changes nothing"
+
+# ============================================================
+echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -105,12 +105,12 @@ make_jsonl_line() {
 }
 
 # ============================================================
-echo "=== Test 1: Output format — all 23 keys present ==="
+echo "=== Test 1: Output format — all 25 keys present ==="
 # ============================================================
 ENV1=$(setup_env "test1")
 OUTPUT1=$(run_script "$ENV1")
 
-EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED USAGE_AGE USAGE_ERROR WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
+EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED USAGE_AGE USAGE_ERROR WEEKLY_SCOPED WEEK_WINDOW_START WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
 for key in $EXPECTED_KEYS; do
     if echo "$OUTPUT1" | grep -q "^${key}="; then
         pass "key $key present"
@@ -1097,6 +1097,68 @@ else
 fi
 assert_eq "$(usage_field "$OUT31" TODAY_COST)" "24.00" "every decorated id matched the pricing table"
 
+# ============================================================
+echo ""
+echo "=== Test 32: week totals cover the rate limit window, not Monday-to-now ==="
+# ============================================================
+# `seven_day.resets_at` lands on a fixed weekday, so the seven days the ring
+# measures rarely start on a Monday. Counting tokens from Monday puts a total
+# from one window next to a percentage from another - on a Monday morning that
+# reads as if the whole weekly percentage came from today's few messages.
+ENV32=$(setup_env "test32")
+write_creds "$ENV32" "$FUTURE_MS"
+
+# Reset two days out ⇒ the window opened five days ago.
+RESET32=$(date -u -d "+2 days" +%Y-%m-%dT03:00:00+00:00)
+WINDOW32=$(date -d "-5 days" +%Y-%m-%d)
+BEFORE32=$(date -d "-6 days" +%Y-%m-%d)
+
+{
+    make_jsonl_line "$BEFORE32" "claude-opus-4" 1000 0 0 0 "sess-before"
+    make_jsonl_line "$WINDOW32" "claude-opus-4" 2000 0 0 0 "sess-edge"
+    make_jsonl_line "$TODAY" "claude-opus-4" 4000 0 0 0 "sess-today"
+} > "$ENV32/.claude/projects/test-project/test.jsonl"
+
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY="{\"five_hour\":{\"utilization\":10,\"resets_at\":\"2099-01-01T00:00:00Z\"},\"seven_day\":{\"utilization\":71,\"resets_at\":\"$RESET32\"},\"extra_usage\":{\"is_enabled\":false},\"limits\":[{\"kind\":\"session\",\"percent\":10},{\"kind\":\"weekly_all\",\"percent\":71},{\"kind\":\"weekly_scoped\",\"percent\":6,\"scope\":{\"model\":{\"display_name\":\"Fable, 1M:x\"}}}]}"
+OUT32=$(run_script "$ENV32")
+unset MOCK_CURL_CODE MOCK_CURL_BODY
+
+assert_eq "$(usage_field "$OUT32" WEEK_WINDOW_START)" "$WINDOW32" \
+    "the window starts seven days before the reset"
+assert_eq "$(usage_field "$OUT32" WEEK_TOKENS)" "6000" \
+    "only the days inside the window are counted"
+assert_eq "$(usage_field "$OUT32" WEEK_SESSIONS)" "2" \
+    "sessions follow the same window"
+assert_eq "$(usage_field "$OUT32" WEEK_MESSAGES)" "2" \
+    "messages follow the same window"
+# The strip below the rings is labelled Mo..Su, so it stays on calendar dates
+# even though the totals above it do not.
+TODAY_IDX32=$(( $(date +%u) - 1 ))
+DAILY32=$(usage_field "$OUT32" DAILY)
+assert_eq "$(echo "$DAILY32" | cut -d, -f$(( TODAY_IDX32 + 1 )))" "4000" \
+    "the daily strip still buckets by calendar day"
+assert_eq "$(usage_field "$OUT32" WEEKLY_SCOPED)" "Fable 1Mx:6" \
+    "a scoped weekly limit is reported per model, delimiters stripped"
+
+# Without a reset to align to there is no window, so the calendar week stands in.
+ENV32B=$(setup_env "test32b")
+CAL_WEEK32=$(date -d "$(( $(date +%u) - 1 )) days ago" +%Y-%m-%d)
+OUT32B=$(run_script "$ENV32B")
+assert_eq "$(usage_field "$OUT32B" WEEK_WINDOW_START)" "$CAL_WEEK32" \
+    "no usable reset falls back to the calendar week"
+assert_eq "$(usage_field "$OUT32B" WEEKLY_SCOPED)" "" \
+    "no response means no scoped limits are invented"
+
+# A plan with no per-model cap must not grow an empty row.
+ENV32C=$(setup_env "test32c")
+write_creds "$ENV32C" "$FUTURE_MS"
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY="{\"five_hour\":{\"utilization\":10,\"resets_at\":\"2099-01-01T00:00:00Z\"},\"seven_day\":{\"utilization\":40,\"resets_at\":\"$RESET32\"},\"limits\":[{\"kind\":\"weekly_all\",\"percent\":40},{\"kind\":\"weekly_scoped\",\"percent\":3,\"scope\":null}]}"
+OUT32C=$(run_script "$ENV32C")
+unset MOCK_CURL_CODE MOCK_CURL_BODY
+assert_eq "$(usage_field "$OUT32C" WEEKLY_SCOPED)" "" \
+    "a scoped row without a model name is dropped"
 # ============================================================
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -30,16 +30,64 @@ setup_env() {
 # Mock curl: avoids real network calls. Mirrors `curl -w '\n%{http_code}'` — body
 # first, then the status on its own line. Tests drive it with MOCK_CURL_BODY and
 # MOCK_CURL_CODE; unset means "empty JSON, no status line", i.e. an unreachable API.
+#
+# The OAuth token endpoint gets its own fixture pair (MOCK_TOKEN_BODY /
+# MOCK_TOKEN_CODE) so a test can make the refresh succeed while the usage call
+# fails, and MOCK_CURL_BODY_2 / MOCK_CURL_CODE_2 answer the second usage call so
+# the 401-refresh-retry path can be driven. Every invocation is appended to
+# CALL_LOG, which is how tests see whether a refresh was attempted at all and
+# which token the retry carried.
+CALL_LOG="$TMPDIR_ROOT/curl-calls.log"
 mock_curl="$TMPDIR_ROOT/curl"
-cat > "$mock_curl" << 'CURLEOF'
+cat > "$mock_curl" << CURLEOF
 #!/usr/bin/env bash
-body="${MOCK_CURL_BODY-}"
-[ -n "$body" ] || body='{}'
-printf '%s' "$body"
-[ -n "${MOCK_CURL_CODE-}" ] && printf '\n%s' "$MOCK_CURL_CODE"
+printf '%s\n' "\$*" >> "$CALL_LOG"
+
+kind=other
+for arg in "\$@"; do
+    case "\$arg" in
+        *oauth/token*) kind=token ;;
+        *oauth/usage*) [ "\$kind" = token ] || kind=usage ;;
+    esac
+done
+
+if [ "\$kind" = token ]; then
+    # Simulates Claude Code refreshing the same credentials while our request is
+    # in flight: the file gains tokens we never asked for.
+    if [ -n "\${MOCK_TOKEN_ROTATE-}" ]; then
+        cat > "\$MOCK_TOKEN_ROTATE" << ROTATEEOF
+{"claudeAiOauth":{"accessToken":"other-access","refreshToken":"other-refresh","expiresAt":\$(( (\$(date +%s) + 3600) * 1000 ))}}
+ROTATEEOF
+    fi
+    body="\${MOCK_TOKEN_BODY-}"
+    [ -n "\$body" ] || body='{}'
+    printf '%s' "\$body"
+    [ -n "\${MOCK_TOKEN_CODE-}" ] && printf '\n%s' "\$MOCK_TOKEN_CODE"
+    exit 0
+fi
+
+body="\${MOCK_CURL_BODY-}"
+code="\${MOCK_CURL_CODE-}"
+if [ "\$kind" = usage ]; then
+    count_file="$TMPDIR_ROOT/usage-calls"
+    n=\$(cat "\$count_file" 2>/dev/null || echo 0)
+    n=\$(( n + 1 ))
+    printf '%s' "\$n" > "\$count_file"
+    if [ "\$n" -ge 2 ] && [ -n "\${MOCK_CURL_BODY_2-}\${MOCK_CURL_CODE_2-}" ]; then
+        body="\${MOCK_CURL_BODY_2-}"
+        code="\${MOCK_CURL_CODE_2-}"
+    fi
+fi
+[ -n "\$body" ] || body='{}'
+printf '%s' "\$body"
+[ -n "\$code" ] && printf '\n%s' "\$code"
 exit 0
 CURLEOF
 chmod +x "$mock_curl"
+
+# Usage: calls_matching <regex> — how many mock curl invocations matched
+calls_matching() { grep -cE "$1" "$CALL_LOG" 2>/dev/null || true; }
+reset_calls() { : > "$CALL_LOG"; rm -f "$TMPDIR_ROOT/usage-calls"; }
 
 run_script() {
     local home_dir="$1"
@@ -842,6 +890,175 @@ assert_eq "$(usage_field "$OUT29" FIVE_HOUR_UTIL)" "7" "--force refetches past a
 assert_eq "$(usage_field "$OUT29" PROFILES)" "default" "--force is not registered as a profile"
 unset MOCK_CURL_CODE MOCK_CURL_BODY
 
+# ============================================================
+echo ""
+echo "=== Test 30: expired access token is refreshed in place ==="
+# ============================================================
+# The widget outlives the ~12h access token. Before this, a dead token meant every
+# fetch was refused until Claude Code itself ran; now the script does the
+# `refresh_token` grant. These assertions guard the credentials file, which is the
+# expensive thing to get wrong: a bad write breaks the user's login.
+ENV30=$(setup_env "test30")
+CREDS30="$ENV30/.claude/.credentials.json"
+STAMP30="$ENV30/.claude/usage-cache-refresh.stamp"
+USAGE_OK30='{"five_hour":{"utilization":9,"resets_at":"2099-01-01T00:00:00Z"},"seven_day":{"utilization":3,"resets_at":"2099-01-07T00:00:00Z"},"extra_usage":{"is_enabled":false}}'
+
+write_refreshable_creds() {
+    # Usage: write_refreshable_creds <expiresAt_ms> <refreshToken> [refreshTokenExpiresAt_ms]
+    # `mcpOAuth` is a key this script knows nothing about - it must survive.
+    local rexp="${3-}"
+    cat > "$CREDS30" << CRED30EOF
+{
+    "claudeAiOauth": {
+        "subscriptionType": "team",
+        "rateLimitTier": "default_claude_max_5x",
+        "accessToken": "old-access",
+        "refreshToken": "$2",
+        "expiresAt": $1,
+        ${rexp:+\"refreshTokenExpiresAt\": $rexp,}
+        "scopes": ["user:profile", "user:inference"]
+    },
+    "mcpOAuth": {"some-server": {"accessToken": "keep-me"}}
+}
+CRED30EOF
+    chmod 600 "$CREDS30"
+}
+
+creds_field() { jq -r "$1" "$CREDS30" 2>/dev/null; }
+# Each sub-case below wants a real fetch, and the previous one leaves a fresh
+# usage cache behind - which would serve numbers and skip the refresh entirely.
+reset30() { reset_calls; rm -f "$ENV30/.claude/usage-cache.json"; }
+
+# --- Expired token, refresh works: numbers go live and the file is updated ---
+write_refreshable_creds "$PAST_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_CODE=200
+export MOCK_TOKEN_BODY='{"access_token":"new-access","refresh_token":"new-refresh","expires_in":43200,"refresh_token_expires_in":2592000,"scope":"user:profile user:inference user:mcp_servers"}'
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY="$USAGE_OK30"
+OUT30A=$(run_script "$ENV30")
+assert_eq "$(usage_field "$OUT30A" USAGE_ERROR)" "" "refreshed token → no warning"
+assert_eq "$(usage_field "$OUT30A" USAGE_AGE)" "0" "refreshed token → live numbers"
+assert_eq "$(usage_field "$OUT30A" FIVE_HOUR_UTIL)" "9" "refreshed token → real utilization"
+assert_eq "$(creds_field '.claudeAiOauth.accessToken')" "new-access" "new access token stored"
+assert_eq "$(creds_field '.claudeAiOauth.refreshToken')" "new-refresh" "rotated refresh token stored"
+assert_eq "$(creds_field '.mcpOAuth."some-server".accessToken')" "keep-me" "unrelated credentials keys survive"
+assert_eq "$(creds_field '.claudeAiOauth.subscriptionType')" "team" "subscription details survive"
+assert_eq "$(creds_field '.claudeAiOauth.scopes | join(",")')" "user:profile,user:inference,user:mcp_servers" \
+    "granted scopes replace the requested ones"
+assert_eq "$(stat -c '%a' "$CREDS30")" "600" "credentials file keeps mode 600"
+EXP30=$(creds_field '.claudeAiOauth.expiresAt')
+if [ "$EXP30" -gt "$(( NOW28 * 1000 ))" ]; then
+    pass "expiresAt moved into the future"
+else
+    fail "expiresAt not renewed (got $EXP30)"
+fi
+assert_eq "$(calls_matching 'Bearer new-access')" "1" "usage fetch used the refreshed token"
+assert_eq "$(calls_matching 'User-Agent: dms-claudecode.*oauth/token')" "1" "the refresh says who it really is"
+assert_eq "$(calls_matching 'User-Agent: claude-code.*oauth/token')" "0" "the refresh does not impersonate Claude Code"
+if [ -f "$STAMP30" ]; then fail "successful refresh left a backoff stamp"; else pass "successful refresh leaves no backoff stamp"; fi
+
+# --- Refresh refused: credentials untouched, user told to run claude ---
+write_refreshable_creds "$PAST_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_CODE=400
+export MOCK_TOKEN_BODY='{"error":"invalid_grant"}'
+export MOCK_CURL_CODE=401
+export MOCK_CURL_BODY='{}'
+OUT30B=$(run_script "$ENV30")
+assert_eq "$(usage_field "$OUT30B" USAGE_ERROR)" "token_expired" "failed refresh → token_expired"
+assert_eq "$(creds_field '.claudeAiOauth.accessToken')" "old-access" "failed refresh does not touch the login"
+assert_eq "$(creds_field '.claudeAiOauth.refreshToken')" "old-refresh" "failed refresh keeps the refresh token"
+if [ -f "$STAMP30" ]; then pass "failed refresh records a backoff stamp"; else fail "no backoff stamp after failure"; fi
+
+# --- Backoff: the next run does not retry a refresh that just failed ---
+reset30
+OUT30C=$(run_script "$ENV30")
+assert_eq "$(calls_matching 'oauth/token')" "0" "backoff suppresses the immediate retry"
+assert_eq "$(usage_field "$OUT30C" USAGE_ERROR)" "token_expired" "backoff still reports the cause"
+rm -f "$STAMP30"
+
+# --- Throttled refresh: the login is fine, so do not tell the user to log in ---
+# The token endpoint refuses some agent strings with a 429 before it even looks at
+# the grant. That is a wait, not a dead login, and the stamp carries the code so
+# the suppressed retry keeps saying the same thing.
+write_refreshable_creds "$PAST_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_CODE=429
+export MOCK_TOKEN_BODY='{"error":{"type":"rate_limit_error","message":"Rate limited. Please try again later."}}'
+OUT30I=$(run_script "$ENV30")
+assert_eq "$(usage_field "$OUT30I" USAGE_ERROR)" "rate_limited" "throttled refresh → rate_limited, not token_expired"
+assert_eq "$(awk 'NR==1 {print $2}' "$STAMP30")" "429" "the stamp records the refresh status code"
+assert_eq "$(creds_field '.claudeAiOauth.accessToken')" "old-access" "throttled refresh does not touch the login"
+reset30
+OUT30J=$(run_script "$ENV30")
+assert_eq "$(calls_matching 'oauth/token')" "0" "throttled refresh backs off like any other failure"
+assert_eq "$(usage_field "$OUT30J" USAGE_ERROR)" "rate_limited" "backoff keeps reporting the throttle"
+rm -f "$STAMP30"
+
+# --- 200 with a body that is not a token: treated as a failure ---
+write_refreshable_creds "$PAST_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_CODE=200
+export MOCK_TOKEN_BODY='{"unexpected":"shape"}'
+OUT30D=$(run_script "$ENV30")
+assert_eq "$(usage_field "$OUT30D" USAGE_ERROR)" "token_expired" "malformed token response → token_expired"
+assert_eq "$(creds_field '.claudeAiOauth.accessToken')" "old-access" "malformed token response does not touch the login"
+rm -f "$STAMP30"
+
+# --- A dead refresh token cannot be refreshed: do not even ask ---
+write_refreshable_creds "$PAST_MS" "old-refresh" "$PAST_MS"
+reset30
+export MOCK_TOKEN_CODE=200
+export MOCK_TOKEN_BODY='{"access_token":"new-access","expires_in":43200}'
+OUT30E=$(run_script "$ENV30")
+assert_eq "$(calls_matching 'oauth/token')" "0" "expired refresh token → no request spent"
+assert_eq "$(usage_field "$OUT30E" USAGE_ERROR)" "token_expired" "expired refresh token → token_expired"
+
+# --- No refresh token at all (old credentials file): no request, same message ---
+write_refreshable_creds "$PAST_MS" "" "$FUTURE_MS"
+reset30
+OUT30F=$(run_script "$ENV30")
+assert_eq "$(calls_matching 'oauth/token')" "0" "missing refresh token → no request spent"
+assert_eq "$(usage_field "$OUT30F" USAGE_ERROR)" "token_expired" "missing refresh token → token_expired"
+rm -f "$STAMP30"
+
+# --- 401 on a token the file still calls valid: refresh, then retry once ---
+write_refreshable_creds "$FUTURE_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_CODE=200
+export MOCK_TOKEN_BODY='{"access_token":"new-access","refresh_token":"new-refresh","expires_in":43200}'
+export MOCK_CURL_CODE=401
+export MOCK_CURL_BODY='{}'
+export MOCK_CURL_CODE_2=200
+export MOCK_CURL_BODY_2="$USAGE_OK30"
+OUT30G=$(run_script "$ENV30")
+assert_eq "$(usage_field "$OUT30G" USAGE_ERROR)" "" "401 on a live token → refresh and retry recovers"
+assert_eq "$(usage_field "$OUT30G" FIVE_HOUR_UTIL)" "9" "retry after refresh returns real numbers"
+assert_eq "$(calls_matching 'oauth/token')" "1" "the retry refreshes exactly once"
+assert_eq "$(calls_matching 'Bearer new-access')" "1" "the retry carries the new token"
+unset MOCK_CURL_CODE_2 MOCK_CURL_BODY_2
+
+# --- Someone else refreshed mid-flight: use their token, leave the file alone ---
+write_refreshable_creds "$PAST_MS" "old-refresh" "$FUTURE_MS"
+reset30
+export MOCK_TOKEN_ROTATE="$CREDS30"
+export MOCK_TOKEN_CODE=200
+export MOCK_TOKEN_BODY='{"access_token":"new-access","refresh_token":"new-refresh","expires_in":43200}'
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY="$USAGE_OK30"
+OUT30H=$(run_script "$ENV30")
+unset MOCK_TOKEN_ROTATE
+assert_eq "$(creds_field '.claudeAiOauth.refreshToken')" "other-refresh" \
+    "a concurrent refresh is not overwritten"
+assert_eq "$(creds_field '.claudeAiOauth.accessToken')" "other-access" \
+    "the concurrent writer's access token is kept"
+assert_eq "$(calls_matching 'Bearer other-access')" "1" "the fetch uses the concurrent writer's token"
+assert_eq "$(usage_field "$OUT30H" USAGE_ERROR)" "" "concurrent refresh still yields live numbers"
+unset MOCK_TOKEN_CODE MOCK_TOKEN_BODY MOCK_CURL_CODE MOCK_CURL_BODY
+
+# ============================================================
+echo ""
 echo "=== Test 31: decorated model ids fold into their family ==="
 # ============================================================
 # Claude Code reports whatever id the backend uses: Bedrock adds a region and a

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -27,11 +27,17 @@ setup_env() {
     echo "$dir"
 }
 
-# Mock curl: always returns empty JSON (avoids real network calls)
+# Mock curl: avoids real network calls. Mirrors `curl -w '\n%{http_code}'` — body
+# first, then the status on its own line. Tests drive it with MOCK_CURL_BODY and
+# MOCK_CURL_CODE; unset means "empty JSON, no status line", i.e. an unreachable API.
 mock_curl="$TMPDIR_ROOT/curl"
 cat > "$mock_curl" << 'CURLEOF'
 #!/usr/bin/env bash
-echo '{}'
+body="${MOCK_CURL_BODY-}"
+[ -n "$body" ] || body='{}'
+printf '%s' "$body"
+[ -n "${MOCK_CURL_CODE-}" ] && printf '\n%s' "$MOCK_CURL_CODE"
+exit 0
 CURLEOF
 chmod +x "$mock_curl"
 
@@ -51,12 +57,12 @@ make_jsonl_line() {
 }
 
 # ============================================================
-echo "=== Test 1: Output format — all 21 keys present ==="
+echo "=== Test 1: Output format — all 23 keys present ==="
 # ============================================================
 ENV1=$(setup_env "test1")
 OUTPUT1=$(run_script "$ENV1")
 
-EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
+EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED USAGE_AGE USAGE_ERROR WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
 for key in $EXPECTED_KEYS; do
     if echo "$OUTPUT1" | grep -q "^${key}="; then
         pass "key $key present"
@@ -714,6 +720,106 @@ if echo "$PROFILES27C" | tr ',' '\n' | grep -q '^alias$'; then
 else
     pass "duplicate config directory registered only once"
 fi
+
+# ============================================================
+echo "=== Test 28: USAGE_ERROR / USAGE_AGE report fetch trust ==="
+# ============================================================
+ENV28=$(setup_env "test28")
+
+write_creds() {
+    # Usage: write_creds <env_dir> <expiresAt_ms>
+    cat > "$1/.claude/.credentials.json" << CRED28EOF
+{
+    "claudeAiOauth": {
+        "subscriptionType": "pro",
+        "rateLimitTier": "t1_pro",
+        "accessToken": "fake-token",
+        "expiresAt": $2
+    }
+}
+CRED28EOF
+}
+
+write_usage_cache() {
+    # Usage: write_usage_cache <env_dir> <cached_at> <five_hour_util>
+    cat > "$1/.claude/usage-cache.json" << CACHE28EOF
+{
+    "cached_at": $2,
+    "identity": "$1/.claude/.credentials.json",
+    "data": {
+        "five_hour": {"utilization": $3, "resets_at": "2099-01-01T00:00:00Z"},
+        "seven_day": {"utilization": 7, "resets_at": "2099-01-07T00:00:00Z"},
+        "extra_usage": {"is_enabled": false}
+    }
+}
+CACHE28EOF
+}
+
+usage_field() { echo "$1" | grep "^$2=" | cut -d= -f2-; }
+
+NOW28=$(date +%s)
+FUTURE_MS=$(( (NOW28 + 3600) * 1000 ))
+PAST_MS=$(( (NOW28 - 3600) * 1000 ))
+
+# No credentials at all
+OUT28A=$(run_script "$ENV28")
+assert_eq "$(usage_field "$OUT28A" USAGE_ERROR)" "no_credentials" "no credentials → no_credentials"
+assert_eq "$(usage_field "$OUT28A" USAGE_AGE)" "0" "no credentials → USAGE_AGE=0"
+
+# Live token, API refuses, nothing cached → error with no age, numbers stay 0
+write_creds "$ENV28" "$FUTURE_MS"
+export MOCK_CURL_CODE=429
+OUT28B=$(run_script "$ENV28")
+assert_eq "$(usage_field "$OUT28B" USAGE_ERROR)" "rate_limited" "HTTP 429 → rate_limited"
+assert_eq "$(usage_field "$OUT28B" USAGE_AGE)" "0" "429 without cache → USAGE_AGE=0"
+assert_eq "$(usage_field "$OUT28B" FIVE_HOUR_UTIL)" "0" "429 without cache → no invented utilization"
+
+# Same failure, but a stale cache exists → cached numbers served WITH their age
+write_usage_cache "$ENV28" "$(( NOW28 - 3600 ))" 42
+OUT28C=$(run_script "$ENV28")
+assert_eq "$(usage_field "$OUT28C" USAGE_ERROR)" "rate_limited" "stale cache keeps the failure reason"
+assert_eq "$(usage_field "$OUT28C" FIVE_HOUR_UTIL)" "42" "stale cache still provides utilization"
+AGE28C=$(usage_field "$OUT28C" USAGE_AGE)
+if [ "$AGE28C" -ge 3600 ] && [ "$AGE28C" -lt 3660 ]; then
+    pass "stale cache reports its age (~3600s, got ${AGE28C}s)"
+else
+    fail "stale cache age expected ~3600s, got '${AGE28C}s'"
+fi
+
+# 401/403 and an unreachable API get their own reasons
+export MOCK_CURL_CODE=401
+assert_eq "$(usage_field "$(run_script "$ENV28")" USAGE_ERROR)" "unauthorized" "HTTP 401 → unauthorized"
+unset MOCK_CURL_CODE
+assert_eq "$(usage_field "$(run_script "$ENV28")" USAGE_ERROR)" "offline" "no HTTP status → offline"
+
+# An expired login outranks the HTTP code: it is the cause the user can act on
+write_creds "$ENV28" "$PAST_MS"
+export MOCK_CURL_CODE=429
+assert_eq "$(usage_field "$(run_script "$ENV28")" USAGE_ERROR)" "token_expired" \
+    "expired token wins over the HTTP code"
+unset MOCK_CURL_CODE
+
+# A successful fetch must clear the warning even though a stale cache is on disk
+write_creds "$ENV28" "$FUTURE_MS"
+export MOCK_CURL_CODE=200
+export MOCK_CURL_BODY='{"five_hour":{"utilization":3,"resets_at":"2099-01-01T00:00:00Z"},"seven_day":{"utilization":1,"resets_at":"2099-01-07T00:00:00Z"},"extra_usage":{"is_enabled":false}}'
+OUT28D=$(run_script "$ENV28")
+assert_eq "$(usage_field "$OUT28D" USAGE_ERROR)" "" "successful fetch → empty USAGE_ERROR"
+assert_eq "$(usage_field "$OUT28D" USAGE_AGE)" "0" "successful fetch → USAGE_AGE=0"
+assert_eq "$(usage_field "$OUT28D" FIVE_HOUR_UTIL)" "3" "successful fetch → live utilization"
+unset MOCK_CURL_CODE MOCK_CURL_BODY
+
+# A cache inside the TTL is a normal hit, not a stale read
+write_usage_cache "$ENV28" "$NOW28" 42
+OUT28E=$(run_script "$ENV28")
+assert_eq "$(usage_field "$OUT28E" USAGE_ERROR)" "" "fresh cache → no warning"
+assert_eq "$(usage_field "$OUT28E" USAGE_AGE)" "0" "fresh cache → USAGE_AGE=0"
+
+# Per-profile lists carry the same two fields
+assert_match "$(usage_field "$OUT28C" PROFILE_USAGE_ERROR)" "default:rate_limited" \
+    "PROFILE_USAGE_ERROR names the profile"
+assert_match "$(usage_field "$OUT28C" PROFILE_USAGE_AGE)" "default:[0-9]+" \
+    "PROFILE_USAGE_AGE names the profile"
 
 # ============================================================
 echo ""

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -100,6 +100,8 @@ function parseLine(line, state) {
     case "SEVEN_DAY_UTIL": state.sevenDayUtil = parseFloat(val) || 0; break
     case "SEVEN_DAY_RESET": state.sevenDayReset = val; break
     case "EXTRA_USAGE_ENABLED": state.extraUsageEnabled = (val === "true"); break
+    case "USAGE_AGE": state.usageAge = parseInt(val) || 0; break
+    case "USAGE_ERROR": state.usageError = val; break
     case "WEEK_MESSAGES": state.weekMessages = parseInt(val) || 0; break
     case "WEEK_SESSIONS": state.weekSessions = parseInt(val) || 0; break
     case "WEEK_TOKENS": state.weekTokens = parseFloat(val) || 0; break
@@ -138,6 +140,34 @@ function parseLine(line, state) {
         break
     }
     return state
+}
+
+function formatAge(seconds) {
+    if (!(seconds > 0)) return "0m"
+    var mins = Math.floor(seconds / 60)
+    if (mins < 60) return mins + "m"
+    var hours = Math.floor(mins / 60)
+    if (hours < 24) return hours + "h " + (mins % 60) + "m"
+    return Math.floor(hours / 24) + "d " + (hours % 24) + "h"
+}
+
+function usageErrorLabel(code) {
+    switch (code) {
+    case "token_expired": return tr("Claude Code login expired")
+    case "rate_limited": return tr("API rate limited")
+    case "unauthorized": return tr("Not authorized")
+    case "offline": return tr("No connection")
+    case "no_credentials": return tr("Not signed in")
+    case "bad_response": return tr("Unexpected API response")
+    default: return code
+    }
+}
+
+function usageWarning(age, err) {
+    if (!err) return ""
+    var reason = usageErrorLabel(err)
+    if (age <= 0) return reason
+    return formatAge(age) + " " + tr("old") + " \u00b7 " + reason
 }
 '
 
@@ -424,6 +454,43 @@ if [ "$RESULT_MODELS_BAD" = '[{"modelName":"opus","modelTokens":5000},{"modelNam
 else
     fail "parseLine WEEK_MODELS malformed expected opus+sonnet only, got $RESULT_MODELS_BAD"
 fi
+
+# ============================================================
+echo "=== Test 8: formatAge / usageWarning ==="
+# ============================================================
+
+test_expr() {
+    local expr="$1" expected="$2" desc="$3" out
+    out=$(run_js "${JS_HARNESS} console.log($expr)")
+    if [ "$out" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc expected '$expected', got '$out'"
+    fi
+}
+
+test_expr "formatAge(0)" "0m" "formatAge(0) = 0m"
+test_expr "formatAge(-5)" "0m" "formatAge(negative) = 0m"
+test_expr "formatAge(59)" "0m" "formatAge(59s) = 0m"
+test_expr "formatAge(60)" "1m" "formatAge(60s) = 1m"
+test_expr "formatAge(3540)" "59m" "formatAge(59m) = 59m"
+test_expr "formatAge(3600)" "1h 0m" "formatAge(1h) = 1h 0m"
+test_expr "formatAge(12990)" "3h 36m" "formatAge(3h36m) = 3h 36m"
+test_expr "formatAge(86400)" "1d 0h" "formatAge(1d) = 1d 0h"
+test_expr "formatAge(187200)" "2d 4h" "formatAge(2d4h) = 2d 4h"
+
+# A healthy fetch must produce no warning at all, whatever the age is
+test_expr "JSON.stringify(usageWarning(0, ''))" '""' "usageWarning silent when no error"
+test_expr "JSON.stringify(usageWarning(99999, ''))" '""' "usageWarning silent on age alone"
+
+test_expr "usageWarning(12990, 'token_expired')" \
+    "3h 36m old · Claude Code login expired" "usageWarning stale token"
+test_expr "usageWarning(0, 'no_credentials')" \
+    "Not signed in" "usageWarning drops age when there is no cached data"
+test_expr "usageWarning(120, 'offline')" \
+    "2m old · No connection" "usageWarning offline"
+test_expr "usageWarning(60, 'http_500')" \
+    "1m old · http_500" "usageWarning passes unknown codes through"
 
 # ============================================================
 echo ""

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -186,6 +186,29 @@ function parseScopedLimits(val) {
     }
     return out
 }
+
+// Monday-first labels rotated so index 0 is the weekday the window starts on.
+function rotateWeekdays(base, windowStart) {
+    var d = new Date(windowStart + "T00:00:00")
+    if (isNaN(d.getTime())) return base
+    var startDow = (d.getDay() + 6) % 7
+    var out = []
+    for (var i = 0; i < 7; i++) out.push(base[(startDow + i) % 7])
+    return out
+}
+
+// Column 0..6 of the strip a date falls in, or -1 outside the window.
+function windowDayIndex(windowStart, when) {
+    var start = new Date(windowStart + "T00:00:00")
+    if (isNaN(start.getTime())) return -1
+    var day = new Date(when.getFullYear(), when.getMonth(), when.getDate())
+    var diff = day.getTime() - start.getTime()
+    var days = Math.round(diff / 86400000)
+    return days >= 0 && days <= 6 ? days : -1
+}
+
+var EN_DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+function localDate(s) { return new Date(s + "T09:00:00") }
 '
 
 # ============================================================
@@ -535,6 +558,34 @@ test_expr "JSON.stringify(parseScopedLimits('Fable:6,broken,Opus:12'))" \
     "one broken row does not lose the good ones"
 test_expr "JSON.stringify(parseScopedLimits('Fable:0'))" \
     '[{"name":"Fable","percent":0}]' "an unused model at 0% is still reported"
+
+# ============================================================
+echo "=== Test 10: the strip follows the rate limit window ==="
+# ============================================================
+
+# 2026-08-06 is a Thursday - the day claude.ai resets this account.
+test_expr "rotateWeekdays(EN_DAYS, '2026-08-06').join(' ')" \
+    "Th Fr Sa Su Mo Tu We" "labels start on the window's weekday"
+test_expr "rotateWeekdays(EN_DAYS, '2026-08-10').join(' ')" \
+    "Mo Tu We Th Fr Sa Su" "a Monday window still reads Mo..Su"
+test_expr "rotateWeekdays(EN_DAYS, '2026-08-09').join(' ')" \
+    "Su Mo Tu We Th Fr Sa" "a Sunday window wraps around the end of the row"
+test_expr "rotateWeekdays(EN_DAYS, '').join(' ')" \
+    "Mo Tu We Th Fr Sa Su" "no window date leaves the row Monday-first"
+
+test_expr "windowDayIndex('2026-08-06', localDate('2026-08-06'))" "0" \
+    "the window's first day is column 0"
+test_expr "windowDayIndex('2026-08-06', localDate('2026-08-10'))" "4" \
+    "a day inside the window is its offset from the start"
+test_expr "windowDayIndex('2026-08-06', localDate('2026-08-12'))" "6" \
+    "the window's last day is column 6"
+# The reset-day morning: the window on screen ends yesterday, so today has no bar.
+test_expr "windowDayIndex('2026-08-06', localDate('2026-08-13'))" "-1" \
+    "the day after the window has no column"
+test_expr "windowDayIndex('2026-08-06', localDate('2026-08-05'))" "-1" \
+    "the day before the window has no column"
+test_expr "windowDayIndex('', localDate('2026-08-10'))" "-1" \
+    "no window date highlights nothing"
 
 # ============================================================
 echo ""

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -169,6 +169,23 @@ function usageWarning(age, err) {
     if (age <= 0) return reason
     return formatAge(age) + " " + tr("old") + " \u00b7 " + reason
 }
+
+// "Fable:6,Opus:12" -> [{ name: "Fable", percent: 6 }, ...]. The script strips
+// `,` `:` `|` from model names, so splitting on them here is safe.
+function parseScopedLimits(val) {
+    var out = []
+    if (!val) return out
+    var entries = val.split(",")
+    for (var i = 0; i < entries.length; i++) {
+        var colon = entries[i].lastIndexOf(":")
+        if (colon <= 0) continue
+        var name = entries[i].substring(0, colon)
+        var pct = parseFloat(entries[i].substring(colon + 1))
+        if (name === "" || isNaN(pct)) continue
+        out.push({ name: name, percent: pct })
+    }
+    return out
+}
 '
 
 # ============================================================
@@ -491,6 +508,33 @@ test_expr "usageWarning(120, 'offline')" \
     "2m old · No connection" "usageWarning offline"
 test_expr "usageWarning(60, 'http_500')" \
     "1m old · http_500" "usageWarning passes unknown codes through"
+
+# ============================================================
+echo "=== Test 9: parseScopedLimits ==="
+# ============================================================
+
+test_expr "JSON.stringify(parseScopedLimits(''))" "[]" \
+    "no scoped limits when the field is empty"
+test_expr "JSON.stringify(parseScopedLimits('Fable:6'))" \
+    '[{"name":"Fable","percent":6}]' "one model with its own weekly cap"
+test_expr "JSON.stringify(parseScopedLimits('Fable:6,Opus:12.5'))" \
+    '[{"name":"Fable","percent":6},{"name":"Opus","percent":12.5}]' \
+    "several models keep their order and fractional percents"
+# The script strips delimiters from names, but a display name can still carry a
+# space; only the last colon separates the percent.
+test_expr "JSON.stringify(parseScopedLimits('Claude Opus 4.5:71'))" \
+    '[{"name":"Claude Opus 4.5","percent":71}]' "a spaced model name survives intact"
+test_expr "JSON.stringify(parseScopedLimits(':50'))" "[]" \
+    "a nameless row is dropped"
+test_expr "JSON.stringify(parseScopedLimits('Fable:'))" "[]" \
+    "a row without a percent is dropped"
+test_expr "JSON.stringify(parseScopedLimits('Fable'))" "[]" \
+    "a row without a separator is dropped"
+test_expr "JSON.stringify(parseScopedLimits('Fable:6,broken,Opus:12'))" \
+    '[{"name":"Fable","percent":6},{"name":"Opus","percent":12}]' \
+    "one broken row does not lose the good ones"
+test_expr "JSON.stringify(parseScopedLimits('Fable:0'))" \
+    '[{"name":"Fable","percent":0}]' "an unused model at 0% is still reported"
 
 # ============================================================
 echo ""

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -153,7 +153,7 @@ function formatAge(seconds) {
 
 function usageErrorLabel(code) {
     switch (code) {
-    case "token_expired": return tr("Claude Code login expired")
+    case "token_expired": return tr("Claude Code login expired - run claude once")
     case "rate_limited": return tr("API rate limited")
     case "unauthorized": return tr("Not authorized")
     case "offline": return tr("No connection")
@@ -484,7 +484,7 @@ test_expr "JSON.stringify(usageWarning(0, ''))" '""' "usageWarning silent when n
 test_expr "JSON.stringify(usageWarning(99999, ''))" '""' "usageWarning silent on age alone"
 
 test_expr "usageWarning(12990, 'token_expired')" \
-    "3h 36m old · Claude Code login expired" "usageWarning stale token"
+    "3h 36m old · Claude Code login expired - run claude once" "usageWarning stale token"
 test_expr "usageWarning(0, 'no_credentials')" \
     "Not signed in" "usageWarning drops age when there is no cached data"
 test_expr "usageWarning(120, 'offline')" \

--- a/tests/test-qml-functions.sh
+++ b/tests/test-qml-functions.sh
@@ -171,7 +171,7 @@ function usageWarning(age, err) {
 }
 
 // "Fable:6,Opus:12" -> [{ name: "Fable", percent: 6 }, ...]. The script strips
-// `,` `:` `|` from model names, so splitting on them here is safe.
+// "," ":" and "|" out of model names, so splitting on them here is safe.
 function parseScopedLimits(val) {
     var out = []
     if (!val) return out

--- a/translations.js
+++ b/translations.js
@@ -35,6 +35,10 @@ var strings = {
         { fr: "messages", es: "mensajes" },
     "Daily Activity":
         { fr: "Activité quotidienne", es: "Actividad diaria" },
+    "Count other clients":
+        { fr: "Compter les autres clients", es: "Contar otros clientes" },
+    "Also count agents that reach this subscription through a bridge, not only Claude Code":
+        { fr: "Compter aussi les agents qui utilisent cet abonnement via une passerelle, pas seulement Claude Code", es: "Contar también los agentes que usan esta suscripción mediante un puente, no solo Claude Code" },
     "Token Consumption":
         { fr: "Consommation de tokens", es: "Consumo de tokens" },
     "Today":

--- a/translations.js
+++ b/translations.js
@@ -13,6 +13,20 @@ var strings = {
         { fr: "Réinitialisation dans", es: "Restablecimiento en" },
     "Resetting...":
         { fr: "Réinitialisation...", es: "Restableciendo..." },
+    "old":
+        { fr: "d'ancienneté", es: "de antigüedad" },
+    "Claude Code login expired":
+        { fr: "Session Claude Code expirée", es: "Sesión de Claude Code caducada" },
+    "API rate limited":
+        { fr: "Limite de l'API atteinte", es: "Límite de la API alcanzado" },
+    "Not authorized":
+        { fr: "Non autorisé", es: "No autorizado" },
+    "No connection":
+        { fr: "Pas de connexion", es: "Sin conexión" },
+    "Not signed in":
+        { fr: "Non connecté", es: "No has iniciado sesión" },
+    "Unexpected API response":
+        { fr: "Réponse inattendue de l'API", es: "Respuesta inesperada de la API" },
     "7-Day Usage":
         { fr: "Utilisation sur 7 jours", es: "Uso durante 7 días" },
     "sessions":

--- a/translations.js
+++ b/translations.js
@@ -15,8 +15,8 @@ var strings = {
         { fr: "Réinitialisation...", es: "Restableciendo..." },
     "old":
         { fr: "d'ancienneté", es: "de antigüedad" },
-    "Claude Code login expired":
-        { fr: "Session Claude Code expirée", es: "Sesión de Claude Code caducada" },
+    "Claude Code login expired - run claude once":
+        { fr: "Session Claude Code expirée - lancez claude une fois", es: "Sesión de Claude Code caducada - ejecuta claude una vez" },
     "API rate limited":
         { fr: "Limite de l'API atteinte", es: "Límite de la API alcanzado" },
     "Not authorized":


### PR DESCRIPTION
**Stacked on #44** — GitHub cannot base a cross-fork PR on another fork's branch, so this targets `master` and therefore shows #44's commits too. Only the last commit, `feat: count the other clients spending this subscription`, is new here. Merge #44 first and this becomes a single-commit diff; if #44 changes shape I'll rebase.

### The problem

The rings measure the *account*, the token totals measured *Claude Code*. Anything that reaches Anthropic through a bridge (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) spends the same rate limit budget from the same subscription, while writing its transcripts somewhere that is not `~/.claude/projects`. A day spent in such a client looks like this:

```
5h Rate Window   16% used
Token Consumption   Today 0   Week 0
Daily Activity   (flat)
```

Nothing is broken about the rings — the tokens are simply invisible to the part of the script that counts them. On this machine that was 179M tokens and ~$200 of usage reported as zero.

### The fix

Record production is split in two, and both producers emit the same eight-field record that the existing awk pass already consumes:

```
<local date> <model> <input> <output> <cache read> <cache write> <session> <cost>
```

- `emit_claude_records` — unchanged behaviour, `~/.claude/projects/**.jsonl`.
- `emit_bridged_records` — [pi](https://github.com/badlogic/pi-mono) transcripts under `${PI_CONFIG_DIR:-~/.pi}`: `agent/sessions/` and `profiles/*/sessions/`. One file per session with the id in the filename, so ids come from there and are prefixed `bridged:` to make a collision with a Claude Code session uuid impossible.

Details worth reviewing:

- **Only Claude models count.** The same harness also drives Gemini and GPT; those tokens are nobody's Claude subscription.
- **`cost` is new**, and Claude Code records always set it to `-1`, meaning "price this from the LiteLLM table" — i.e. the existing path is untouched. A transcript that priced the call itself hands the number over, which is the only way to cost a model the table has never heard of: `claude-fable-5` folds to family `fable`, finds no row, and would otherwise bill as $0.
- **Attribution:** bridged usage belongs to the `default` profile, because that is the login whose rate limit rings the popout puts these totals next to.
- **Opt-out:** *Count other clients* in the settings (on by default) passes `--no-bridged` and reproduces the old numbers exactly. Default-on is deliberate: "Today 0" under a ring at 16% is the state that reads as a bug.

### Tests

New Test 34, 9 assertions: bridged Claude tokens counted while other vendors are not, one session per transcript file, only assistant answers counted as messages, an unpriceable model still getting its own row and its own cost, `--no-bridged` reproducing the Claude-Code-only totals, and a machine with no bridged transcripts anywhere behaving identically.

`tests/test-get-claude-usage.sh`: 192 passed, 0 failed. Full suite green (plugin.json, qml-functions, qml-syntax, translations). FR/ES strings added for the new setting.

### Verified live

DMS 5h ring 18% / today formerly 0 → `TODAY_TOKENS=179078321`, `TODAY_COST=201.25`, daily strip `2.0M, 64.4M, 0, 0, 179.1M, 0, 0`, per-model `opus=137.1M, fable=103.3M, sonnet=5.1M`. Extra cost of the scan on 47 transcript files: ~0.6s.
