### PR TITLE
Bound stale-cache fallback in fetch_profile_usage; add USAGE_STALE signal

### DIFF
--- a/ClaudeCodeUsageWidget.qml
+++ b/ClaudeCodeUsageWidget.qml
@@ -39,6 +39,10 @@ PluginComponent {
     property real sevenDayUtil: 0
     property string sevenDayReset: ""
     property bool extraUsageEnabled: false
+    // True when the values above are NOT freshly confirmed — the last live
+    // usage check failed (e.g. expired credentials) and we're either showing
+    // an older cached snapshot or, past USAGE_STALE_MAX_AGE, no data at all.
+    property bool usageStale: false
 
     // Weekly state
     property int weekMessages: 0
@@ -101,6 +105,7 @@ PluginComponent {
     property string displayFiveHourReset: currentPd && currentPd.fiveHourReset !== undefined ? currentPd.fiveHourReset : fiveHourReset
     property real displaySevenDayUtil: currentPd && currentPd.sevenDayUtil !== undefined ? currentPd.sevenDayUtil : sevenDayUtil
     property string displaySevenDayReset: currentPd && currentPd.sevenDayReset !== undefined ? currentPd.sevenDayReset : sevenDayReset
+    property bool displayUsageStale: currentPd && currentPd.usageStale !== undefined ? currentPd.usageStale : usageStale
     property real displayWeekTokens: currentPd && currentPd.weekTokens !== undefined ? currentPd.weekTokens : weekTokens
     property int displayWeekMessages: currentPd && currentPd.weekMessages !== undefined ? currentPd.weekMessages : weekMessages
     property int displayWeekSessions: currentPd && currentPd.weekSessions !== undefined ? currentPd.weekSessions : weekSessions
@@ -474,6 +479,9 @@ PluginComponent {
         case "EXTRA_USAGE_ENABLED":
             extraUsageEnabled = (val === "true");
             break;
+        case "USAGE_STALE":
+            usageStale = (val === "true");
+            break;
         case "WEEK_MESSAGES":
             weekMessages = parseInt(val) || 0;
             break;
@@ -600,6 +608,9 @@ PluginComponent {
             break;
         case "PROFILE_EXTRA_USAGE":
             profileData = parseProfileBool(val, "extraUsageEnabled");
+            break;
+        case "PROFILE_USAGE_STALE":
+            profileData = parseProfileBool(val, "usageStale");
             break;
         case "PROFILE_DAILY":
             {
@@ -775,7 +786,7 @@ PluginComponent {
             }
 
             StyledText {
-                text: Math.round(root.fiveHourUtil) + "%" + (root.pillOverPace ? " ↑" : "")
+                text: Math.round(root.fiveHourUtil) + "%" + (root.usageStale ? " ⚠" : "") + (root.pillOverPace ? " ↑" : "")
                 font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                 color: root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
                 anchors.verticalCenter: parent.verticalCenter
@@ -822,7 +833,7 @@ PluginComponent {
             }
 
             StyledText {
-                text: Math.round(root.fiveHourUtil) + "%" + (root.pillOverPace ? " ↑" : "")
+                text: Math.round(root.fiveHourUtil) + "%" + (root.usageStale ? " ⚠" : "") + (root.pillOverPace ? " ↑" : "")
                 font.pixelSize: Theme.barTextSize(root.barThickness, root.barConfig?.fontScale, root.barConfig?.maximizeWidgetText)
                 color: root.pillOverPace ? root.paceColor(root.pillFivePace.status) : Theme.surfaceText
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -972,7 +983,10 @@ PluginComponent {
             headerText: root.tr("Claude Code Usage")
             detailsText: {
                 var label = root.formatSubscription(root.displaySubscriptionType, root.displayRateLimitTier);
-                return label ? root.tr("Subscription") + ": " + label : "";
+                var text = label ? root.tr("Subscription") + ": " + label : "";
+                if (root.displayUsageStale)
+                    text += (text ? " · " : "") + root.tr("Live check failed — showing cached data");
+                return text;
             }
             showCloseButton: true
 

--- a/get-claude-usage
+++ b/get-claude-usage
@@ -9,6 +9,7 @@ STATS_CACHE="${CLAUDE_DIR}/stats-cache.json"
 PRICING_CACHE="${CLAUDE_DIR}/pricing-cache.json"
 USAGE_CACHE="${CLAUDE_DIR}/usage-cache.json"
 USAGE_CACHE_TTL=90  # seconds, below the 2 min minimum refresh interval
+USAGE_STALE_MAX_AGE=86400  # seconds; beyond this, a failed API call is not backed by cache
 LITELLM_URL="https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
 
 CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "2.0.0")
@@ -27,6 +28,7 @@ FIVE_HOUR_RESET=""
 SEVEN_DAY_UTIL=0
 SEVEN_DAY_RESET=""
 EXTRA_USAGE_ENABLED="false"
+USAGE_STALE="false"
 
 WEEK_TOKENS=0
 WEEK_MESSAGES=0
@@ -229,7 +231,10 @@ count_profile_tokens() {
 # --- Per-profile credentials + API usage fetcher ---
 # Usage: fetch_profile_usage <credentials_file> <cache_file> <out_tmpfile>
 # Writes SUBSCRIPTION_TYPE, RATE_LIMIT_TIER, FIVE_HOUR_UTIL, FIVE_HOUR_RESET,
-#        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED to out_tmpfile
+#        SEVEN_DAY_UTIL, SEVEN_DAY_RESET, EXTRA_USAGE_ENABLED, USAGE_STALE to out_tmpfile
+# USAGE_STALE is "true" whenever the values shown were NOT just confirmed live —
+# i.e. the API call failed and we either reused an old cached response (still
+# within USAGE_STALE_MAX_AGE) or had nothing usable to fall back on at all.
 fetch_profile_usage() {
     local creds_file="$1"
     local cache_file="$2"
@@ -238,10 +243,11 @@ fetch_profile_usage() {
     local sub_type="unknown"
     local tier="unknown"
     local five_util=0 five_reset="" seven_util=0 seven_reset="" extra="false"
+    local stale="false"
 
     if [ ! -f "$creds_file" ]; then
-        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
-            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+        printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_STALE=%s\n' \
+            "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$stale" > "$out_file"
         return
     fi
 
@@ -292,9 +298,20 @@ fetch_profile_usage() {
                 else
                     rm -f "$cache_tmp"
                 fi
-            elif [ "$cache_matches" = true ]; then
-                api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
+            else
+                # Live call failed (expired/invalid token, network error, ...).
+                # Only fall back to the old cache within a bounded staleness
+                # window — past that, an ancient response would look just as
+                # "current" as a live one, silently misleading the widget.
+                stale="true"
+                if [ "$cache_matches" = true ] && [ "$age" -lt "$USAGE_STALE_MAX_AGE" ]; then
+                    api_resp=$(jq -r '.data // {}' "$cache_file" 2>/dev/null || echo '{}')
+                else
+                    api_resp="{}"
+                fi
             fi
+        else
+            stale="true"
         fi
     fi
 
@@ -304,8 +321,8 @@ fetch_profile_usage() {
     seven_reset=$(echo "$api_resp" | jq -r '.seven_day.resets_at // ""')
     extra=$(echo "$api_resp" | jq -r '.extra_usage.is_enabled // false')
 
-    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\n' \
-        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" > "$out_file"
+    printf 'SUBSCRIPTION_TYPE=%s\nRATE_LIMIT_TIER=%s\nFIVE_HOUR_UTIL=%s\nFIVE_HOUR_RESET=%s\nSEVEN_DAY_UTIL=%s\nSEVEN_DAY_RESET=%s\nEXTRA_USAGE_ENABLED=%s\nUSAGE_STALE=%s\n' \
+        "$sub_type" "$tier" "$five_util" "$five_reset" "$seven_util" "$seven_reset" "$extra" "$stale" > "$out_file"
 }
 
 # --- Collect profile list ---
@@ -433,6 +450,7 @@ PROF_SEVEN_DAY_UTIL=""
 PROF_FIVE_HOUR_RESET_LIST=""
 PROF_SEVEN_DAY_RESET_LIST=""
 PROF_EXTRA_USAGE_LIST=""
+PROF_USAGE_STALE_LIST=""
 
 for idx in "${!TMPFILES[@]}"; do
     tmpf="${TMPFILES[$idx]}"
@@ -454,7 +472,7 @@ for idx in "${!TMPFILES[@]}"; do
 
     # Read per-profile usage/subscription
     p_sub="unknown"; p_tier="unknown"
-    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"
+    p_5u=0; p_5r=""; p_7u=0; p_7r=""; p_extra="false"; p_stale="false"
     if [ -f "$usage_tmpf" ]; then
         p_sub=$(grep "^SUBSCRIPTION_TYPE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
         p_tier=$(grep "^RATE_LIMIT_TIER=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "unknown")
@@ -463,6 +481,7 @@ for idx in "${!TMPFILES[@]}"; do
         p_7u=$(grep "^SEVEN_DAY_UTIL=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo 0)
         p_7r=$(grep "^SEVEN_DAY_RESET=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "")
         p_extra=$(grep "^EXTRA_USAGE_ENABLED=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "false")
+        p_stale=$(grep "^USAGE_STALE=" "$usage_tmpf" 2>/dev/null | cut -d= -f2- || echo "false")
     fi
 
     # Default profile drives the top-level aggregate fields
@@ -474,6 +493,7 @@ for idx in "${!TMPFILES[@]}"; do
         SEVEN_DAY_UTIL="$p_7u"
         SEVEN_DAY_RESET="$p_7r"
         EXTRA_USAGE_ENABLED="$p_extra"
+        USAGE_STALE="$p_stale"
     fi
 
     # Aggregate token totals
@@ -521,6 +541,7 @@ for idx in "${!TMPFILES[@]}"; do
     PROF_FIVE_HOUR_RESET_LIST="${PROF_FIVE_HOUR_RESET_LIST:+${PROF_FIVE_HOUR_RESET_LIST},}${pname}:${p_5r}"
     PROF_SEVEN_DAY_RESET_LIST="${PROF_SEVEN_DAY_RESET_LIST:+${PROF_SEVEN_DAY_RESET_LIST},}${pname}:${p_7r}"
     PROF_EXTRA_USAGE_LIST="${PROF_EXTRA_USAGE_LIST:+${PROF_EXTRA_USAGE_LIST},}${pname}:${p_extra}"
+    PROF_USAGE_STALE_LIST="${PROF_USAGE_STALE_LIST:+${PROF_USAGE_STALE_LIST},}${pname}:${p_stale}"
 
     rm -f "$tmpf" "$usage_tmpf"
 done
@@ -548,6 +569,7 @@ echo "FIVE_HOUR_RESET=${FIVE_HOUR_RESET}"
 echo "SEVEN_DAY_UTIL=${SEVEN_DAY_UTIL}"
 echo "SEVEN_DAY_RESET=${SEVEN_DAY_RESET}"
 echo "EXTRA_USAGE_ENABLED=${EXTRA_USAGE_ENABLED}"
+echo "USAGE_STALE=${USAGE_STALE}"
 echo "WEEK_MESSAGES=${WEEK_MESSAGES}"
 echo "WEEK_SESSIONS=${WEEK_SESSIONS}"
 echo "WEEK_TOKENS=${WEEK_TOKENS}"
@@ -580,3 +602,4 @@ echo "PROFILE_SEVEN_DAY_UTIL=${PROF_SEVEN_DAY_UTIL}"
 echo "PROFILE_FIVE_HOUR_RESET=${PROF_FIVE_HOUR_RESET_LIST}"
 echo "PROFILE_SEVEN_DAY_RESET=${PROF_SEVEN_DAY_RESET_LIST}"
 echo "PROFILE_EXTRA_USAGE=${PROF_EXTRA_USAGE_LIST}"
+echo "PROFILE_USAGE_STALE=${PROF_USAGE_STALE_LIST}"

--- a/tests/test-get-claude-usage.sh
+++ b/tests/test-get-claude-usage.sh
@@ -42,6 +42,18 @@ run_script() {
     HOME="$home_dir" PATH="$TMPDIR_ROOT:$PATH" bash "$SCRIPT" "$@" 2>/dev/null
 }
 
+# Like run_script, but with a custom curl mock (for simulating a successful
+# API response, distinct from the default always-empty mock above).
+run_script_with_curl() {
+    local home_dir="$1" curl_body="$2"
+    shift 2
+    local curl_dir="$TMPDIR_ROOT/curlbin_$RANDOM$RANDOM"
+    mkdir -p "$curl_dir"
+    printf '%s\n' "$curl_body" > "$curl_dir/curl"
+    chmod +x "$curl_dir/curl"
+    HOME="$home_dir" PATH="$curl_dir:$TMPDIR_ROOT:$PATH" bash "$SCRIPT" "$@" 2>/dev/null
+}
+
 # Build a JSONL fixture line
 # Usage: make_jsonl_line <date> <model> <input> <output> <cache_read> <cache_write> <sessionId>
 make_jsonl_line() {
@@ -56,7 +68,7 @@ echo "=== Test 1: Output format — all 21 keys present ==="
 ENV1=$(setup_env "test1")
 OUTPUT1=$(run_script "$ENV1")
 
-EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
+EXPECTED_KEYS="SUBSCRIPTION_TYPE RATE_LIMIT_TIER FIVE_HOUR_UTIL FIVE_HOUR_RESET SEVEN_DAY_UTIL SEVEN_DAY_RESET EXTRA_USAGE_ENABLED USAGE_STALE WEEK_MESSAGES WEEK_SESSIONS WEEK_TOKENS WEEK_MODELS ALLTIME_SESSIONS ALLTIME_MESSAGES FIRST_SESSION DAILY MONTH_TOKENS TODAY_COST WEEK_COST MONTH_COST DAILY_COSTS USD_EUR_RATE"
 for key in $EXPECTED_KEYS; do
     if echo "$OUTPUT1" | grep -q "^${key}="; then
         pass "key $key present"
@@ -714,6 +726,91 @@ if echo "$PROFILES27C" | tr ',' '\n' | grep -q '^alias$'; then
 else
     pass "duplicate config directory registered only once"
 fi
+
+# ============================================================
+echo "=== Test 28: Live API success — USAGE_STALE=false, fresh values used ==="
+# ============================================================
+ENV28=$(setup_env "test28")
+cat > "$ENV28/.claude/.credentials.json" << 'CREDEOF'
+{
+    "claudeAiOauth": {
+        "subscriptionType": "pro",
+        "rateLimitTier": "t1_pro",
+        "accessToken": "fake-token"
+    }
+}
+CREDEOF
+OUTPUT28=$(run_script_with_curl "$ENV28" \
+    'echo "{\"five_hour\":{\"utilization\":55,\"resets_at\":\"2099-01-01T00:00:00Z\"},\"seven_day\":{\"utilization\":20,\"resets_at\":\"2099-01-07T00:00:00Z\"}}"')
+assert_eq "$(echo "$OUTPUT28" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)" "55" "Live success: FIVE_HOUR_UTIL from API"
+assert_eq "$(echo "$OUTPUT28" | grep "^USAGE_STALE=" | cut -d= -f2)" "false" "Live success: USAGE_STALE=false"
+
+# ============================================================
+echo "=== Test 29: API failure, cache within staleness window — old data served, marked stale ==="
+# ============================================================
+ENV29=$(setup_env "test29")
+cat > "$ENV29/.claude/.credentials.json" << 'CREDEOF'
+{
+    "claudeAiOauth": {
+        "subscriptionType": "pro",
+        "rateLimitTier": "t1_pro",
+        "accessToken": "expired-token"
+    }
+}
+CREDEOF
+# Cache is older than USAGE_CACHE_TTL (so the script must attempt a live call)
+# but well within USAGE_STALE_MAX_AGE (86400s) — one hour old.
+STALE_TS=$(( $(date +%s) - 3600 ))
+cat > "$ENV29/.claude/usage-cache.json" << CACHEEOF
+{
+    "cached_at": $STALE_TS,
+    "identity": "$ENV29/.claude/.credentials.json",
+    "data": {
+        "five_hour": {"utilization": 77, "resets_at": "2099-01-01T00:00:00Z"},
+        "seven_day": {"utilization": 33, "resets_at": "2099-01-07T00:00:00Z"}
+    }
+}
+CACHEEOF
+# Default mock curl (always returns "{}") simulates a failed/expired-token API call
+OUTPUT29=$(run_script "$ENV29")
+assert_eq "$(echo "$OUTPUT29" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)" "77" "1h-old cache still served on API failure"
+assert_eq "$(echo "$OUTPUT29" | grep "^USAGE_STALE=" | cut -d= -f2)" "true" "1h-old fallback marked USAGE_STALE=true"
+
+# ============================================================
+echo "=== Test 30: API failure, cache older than USAGE_STALE_MAX_AGE — not served, marked stale ==="
+# ============================================================
+ENV30=$(setup_env "test30")
+cat > "$ENV30/.claude/.credentials.json" << 'CREDEOF'
+{
+    "claudeAiOauth": {
+        "subscriptionType": "pro",
+        "rateLimitTier": "t1_pro",
+        "accessToken": "expired-token"
+    }
+}
+CREDEOF
+# Cache is 3 days old — well past USAGE_STALE_MAX_AGE (86400s = 1 day)
+ANCIENT_TS=$(( $(date +%s) - 259200 ))
+cat > "$ENV30/.claude/usage-cache.json" << CACHEEOF
+{
+    "cached_at": $ANCIENT_TS,
+    "identity": "$ENV30/.claude/.credentials.json",
+    "data": {
+        "five_hour": {"utilization": 80, "resets_at": "2020-01-01T00:00:00Z"},
+        "seven_day": {"utilization": 10, "resets_at": "2020-01-07T00:00:00Z"}
+    }
+}
+CACHEEOF
+OUTPUT30=$(run_script "$ENV30")
+assert_eq "$(echo "$OUTPUT30" | grep "^FIVE_HOUR_UTIL=" | cut -d= -f2)" "0" "3-day-old cache not served, defaults to unknown"
+assert_eq "$(echo "$OUTPUT30" | grep "^USAGE_STALE=" | cut -d= -f2)" "true" "Ancient/no fallback marked USAGE_STALE=true"
+
+# ============================================================
+echo "=== Test 31: Missing credentials — USAGE_STALE=false (not-logged-in, not stale) ==="
+# ============================================================
+ENV31=$(setup_env "test31")
+OUTPUT31=$(run_script "$ENV31")
+assert_eq "$(echo "$OUTPUT31" | grep "^USAGE_STALE=" | cut -d= -f2)" "false" "Missing credentials: USAGE_STALE=false"
 
 # ============================================================
 echo ""

--- a/translations.js
+++ b/translations.js
@@ -5,6 +5,8 @@ var strings = {
         { fr: "Utilisation Claude Code", es: "Uso de Claude Code" },
     "Subscription":
         { fr: "Abonnement", es: "Suscripción" },
+    "Live check failed — showing cached data":
+        { fr: "Échec de la vérification en direct — affichage des données en cache", es: "Fallo la verificación en vivo — mostrando datos en caché" },
     "5h Rate Window":
         { fr: "Fenêtre de 5 h", es: "Ventana de 5 h" },
     "used":


### PR DESCRIPTION
## Summary

Fixes #46 — the usage-check pill can silently show data from days ago as if it were live.

`fetch_profile_usage()` fell back to the last cached API response whenever a live call to `/api/oauth/usage` failed, with no bound on the cache's age. There's an existing TTL check (`USAGE_CACHE_TTL`, 90s) for the *fast path* (skip the API call entirely if the cache is fresh), but the *failure fallback* only checked that the cache belonged to the same credentials file — not how old it was. A response cached days ago got served exactly as if it had just been fetched.

I hit this because I use the Claude Code build bundled with Claude Desktop, which authenticates each session via an injected `CLAUDE_CODE_OAUTH_TOKEN` env var rather than reading/writing `~/.claude/.credentials.json`. Nothing ever refreshes that file on disk, its access token quietly expired after its normal lifetime, every API call from the plugin started 401ing — and the pill just kept showing the last numbers from before expiry, indefinitely, with no visible sign anything was wrong. Repro details are in #46.

## Changes

- **`get-claude-usage`**: bound the failure-fallback to a new `USAGE_STALE_MAX_AGE` (24h). Past that window, report unknown (same defaults as the existing "no credentials file" case) instead of a plausible-but-ancient number. Added a `USAGE_STALE` output field (`true`/`false`, plus a `PROFILE_USAGE_STALE` per-profile variant) so callers can tell "confirmed live" apart from "couldn't refresh, showing what we have".
- **`ClaudeCodeUsageWidget.qml`**: parses `USAGE_STALE`/`PROFILE_USAGE_STALE` following the existing `extraUsageEnabled` pattern (incl. the `displayUsageStale` per-profile override). Taskbar pill appends a small ⚠ when stale; popout details line gets a short note. New translation key added with fr/es entries (`tests/test-translations.sh` enforces this).
- **`tests/test-get-claude-usage.sh`**: 8 new assertions (Tests 28–31) covering live success, in-window stale fallback, past-window fallback rejection, and the missing-credentials case; `USAGE_STALE` added to the Test 1 key-presence list. Added a `run_script_with_curl` helper for tests that need to simulate a successful API response (existing mock `curl` always returns `{}`).

## Testing

All 5 test files pass locally (`tests/test-*.sh`): 103 passed in `test-get-claude-usage.sh` (was 95), plus `test-qml-syntax.sh`, `test-qml-functions.sh`, `test-plugin-json.sh`, `test-translations.sh` all green. I don't have `shellcheck` available locally to run the CI lint job directly, but kept quoting/style consistent with the surrounding code.

Also manually reproduced the original bug against the fixed script (expired token + ~2.3-day-old cache):
```
FIVE_HOUR_UTIL=0
SEVEN_DAY_UTIL=0
USAGE_STALE=true
```
instead of silently replaying the old 80%/10% values.

## Scope note

I kept this focused on the fallback bug itself. I did *not* address the deeper "how do I keep the credentials file refreshed while only using Desktop" question — that's a client-side workaround (e.g. periodically running `claude auth status`), not something this plugin can fix. Happy to adjust the staleness window, output format, or drop the QML visual change if you'd rather keep this PR script-only — let me know.
